### PR TITLE
Line 648 had a stray "m", preventing toTriples() from running.  Fixed here

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -645,7 +645,7 @@ jsonld.toTriples = function(input, callback)
                break;
             }
          }
-      }m
+      }
       if(quit)
       {
          break;


### PR DESCRIPTION
Commit note says it all...
