### PR TITLE
added support for Object.keys method if missing in browser

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -26,6 +26,20 @@ if(typeof(window) !== 'undefined')
    {
       _setMembers(this, obj);
    }
+
+   // define js 1.8.5 Object.keys method unless present
+   if(!Object.keys) 
+       Object.keys = function(o){  
+           if (o !== Object(o))  
+               throw new TypeError('Object.keys called on non-object');  
+           var ret=[],p;  
+           for(p in o) {
+               if(Object.prototype.hasOwnProperty.call(o,p)) 
+                   ret.push(p); 
+           }
+           return ret;
+       }
+
 }
 // define node.js module
 else if(typeof(module) !== 'undefined' && module.exports)


### PR DESCRIPTION
Small fix to add the Object.keys method if it is not present in the browser. 

I noticed the problem testint the parser in Opera 11.52 for OSX
