### PR TITLE
Added async as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "request": "",
     "xmldom": ""
   },
+  "dependencies" : {
+    "async" : "0.1.22"
+  },
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
Added **async** as a dependency in the package description, it seems it's required to run the tests.
