### PR TITLE
IE8 compatibility fixes

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -197,7 +197,7 @@ jsonld.compact = function(input, ctx, options, callback) {
     // remove empty contexts
     var tmp = ctx;
     ctx = [];
-    for(var i in tmp) {
+    for(var i=0;i<tmp.length;i++) {
       if(!_isObject(tmp[i]) || Object.keys(tmp[i]).length > 0) {
         ctx.push(tmp[i]);
       }
@@ -939,7 +939,20 @@ JsonLdProcessor.prototype.toString = function() {
   return '[object JsonLdProcessorPrototype]';
 };
 jsonld.JsonLdProcessor = JsonLdProcessor;
-if(Object.defineProperty) {
+
+// IE8 has Object.defineProperty but it only
+// works on DOM nodes -- so feature detection
+// requries try/catch :-(
+var canDefineProperty = (!!Object.defineProperty);
+if (canDefineProperty){
+  try {
+    Object.defineProperty({}, 'x', {});
+  } catch(e) {
+    canDefineProperty = false;
+  }
+}
+
+if(canDefineProperty) {
   Object.defineProperty(JsonLdProcessor, 'prototype', {
     writable: false,
     enumerable: false
@@ -951,21 +964,6 @@ if(Object.defineProperty) {
     value: JsonLdProcessor
   });
 }
-// setup browser global JsonLdProcessor
-if(_browser && typeof global.JsonLdProcessor === 'undefined') {
-  if(Object.defineProperty) {
-    Object.defineProperty(global, 'JsonLdProcessor', {
-      writable: true,
-      enumerable: false,
-      configurable: true,
-      value: JsonLdProcessor
-    });
-  }
-  else {
-    global.JsonLdProcessor = JsonLdProcessor;
-  }
-}
-
 /* Utility API */
 
 // define setImmediate and nextTick
@@ -1303,7 +1301,7 @@ jsonld.hasValue = function(subject, property, value) {
       if(isList) {
         val = val['@list'];
       }
-      for(var i in val) {
+      for(var i=0;i<val.length;i++) {
         if(jsonld.compareValues(value, val[i])) {
           rval = true;
           break;
@@ -1345,7 +1343,7 @@ jsonld.addValue = function(subject, property, value, options) {
       !(property in subject)) {
       subject[property] = [];
     }
-    for(var i in value) {
+    for(var i=0;i<value.length;i++) {
       jsonld.addValue(subject, property, value[i], options);
     }
   }
@@ -1614,7 +1612,7 @@ Processor.prototype.compact = function(
   // recursively compact array
   if(_isArray(element)) {
     var rval = [];
-    for(var i in element) {
+    for(var i=0;i<element.length;i++) {
       // compact, dropping any null values
       var compacted = this.compact(
         activeCtx, activeProperty, element[i], options);
@@ -1860,7 +1858,7 @@ Processor.prototype.expand = function(
   // recursively expand array
   if(_isArray(element)) {
     var rval = [];
-    for(var i in element) {
+    for(var i=0;i<element.length;i++) {
       // expand element
       var e = self.expand(
         activeCtx, activeProperty, element[i], options, insideList);
@@ -3399,7 +3397,7 @@ function _getAdjacentBlankNodeName(node, id) {
 function _createNodeMap(input, graphs, graph, namer, name, list) {
   // recurse through array
   if(_isArray(input)) {
-    for(var i in input) {
+    for(var i=0;i<input.length;i++) {
       _createNodeMap(input[i], graphs, graph, namer, undefined, list);
     }
     return;
@@ -3611,7 +3609,7 @@ function _frame(state, subjects, frame, parent, property) {
       // existing embed's parent is an array
       var existing = state.embeds[id];
       if(_isArray(existing.parent)) {
-        for(var i in existing.parent) {
+        for(var i=0;i<existing.parent.length;i++) {
           if(jsonld.compareValues(output, existing.parent[i])) {
             embedOn = true;
             break;
@@ -3640,8 +3638,8 @@ function _frame(state, subjects, frame, parent, property) {
       // iterate over subject properties
       var subject = matches[id];
       var props = Object.keys(subject).sort();
-      for(var i in props) {
-        var prop = props[i];
+      for(var j=0; j<props.length;j++) {
+        var prop = props[j];
 
         // copy keywords to output
         if(_isKeyword(prop)) {
@@ -3660,7 +3658,7 @@ function _frame(state, subjects, frame, parent, property) {
 
         // add objects
         var objects = subject[prop];
-        for(var i in objects) {
+        for(var i=0;i<objects.length;i++) {
           var o = objects[i];
 
           // recurse into list
@@ -3698,7 +3696,7 @@ function _frame(state, subjects, frame, parent, property) {
 
       // handle defaults
       var props = Object.keys(frame).sort();
-      for(var i in props) {
+      for(var i=0;i<props.length;i++) {
         var prop = props[i];
 
         // skip keywords
@@ -3768,7 +3766,7 @@ function _validateFrame(state, frame) {
 function _filterSubjects(state, subjects, frame) {
   // filter subjects in @id order
   var rval = {};
-  for(var i in subjects) {
+  for(var i=0;i<subjects.length;i++) {
     var id = subjects[i];
     var subject = state.subjects[id];
     if(_filterSubject(subject, frame)) {
@@ -3791,7 +3789,7 @@ function _filterSubject(subject, frame) {
   if('@type' in frame &&
     !(frame['@type'].length === 1 && _isObject(frame['@type'][0]))) {
     var types = frame['@type'];
-    for(var i in types) {
+    for(var i=0;i<types.length;i++) {
       // any matching @type is a match
       if(jsonld.hasValue(subject, '@type', types[i])) {
         return true;
@@ -3822,7 +3820,7 @@ function _filterSubject(subject, frame) {
 function _embedValues(state, subject, property, output) {
   // embed subject properties in output
   var objects = subject[property];
-  for(var i in objects) {
+  for(var i=0;i<objects.length;i++) {
     var o = objects[i];
 
     // recurse into @list
@@ -3882,7 +3880,7 @@ function _removeEmbed(state, id) {
   // remove existing embed
   if(_isArray(parent)) {
     // replace subject with reference
-    for(var i in parent) {
+    for(var i=0;i<parent.length;i++) {
       if(jsonld.compareValues(parent[i], subject)) {
         parent[i] = subject;
         break;
@@ -3900,7 +3898,7 @@ function _removeEmbed(state, id) {
   var removeDependents = function(id) {
     // get embed keys as a separate array to enable deleting keys in map
     var ids = Object.keys(embeds);
-    for(var i in ids) {
+    for(var i=0;i<ids.length;i++) {
       var next = ids[i];
       if(next in embeds && _isObject(embeds[next].parent) &&
         embeds[next].parent['@id'] === id) {
@@ -3942,7 +3940,7 @@ function _removePreserve(ctx, input, options) {
   // recurse through arrays
   if(_isArray(input)) {
     var output = [];
-    for(var i in input) {
+    for(var i=0;i<input.length;i++) {
       var result = _removePreserve(ctx, input[i], options);
       // drop nulls from arrays
       if(result !== null) {
@@ -5013,7 +5011,7 @@ function _validateTypeValue(v) {
   if(_isArray(v)) {
     // must contain only strings
     isValid = true;
-    for(var i in v) {
+    for(var i=0;i<v.length;i++) {
       if(!(_isString(v[i]))) {
         isValid = false;
         break;
@@ -5204,8 +5202,14 @@ function _isAbsoluteIri(v) {
  * @return the cloned value.
  */
 function _clone(value) {
-  if(value && typeof value === 'object') {
-    var rval = _isArray(value) ? [] : {};
+  if(value && _isArray(value)) {
+    var rval = [];
+    for(var i=0;i<value.length;i++) {
+      rval[i] = _clone(value[i]);
+    }
+   }
+  else if(value && typeof value === 'object') {
+    var rval = {};
     for(var i in value) {
       rval[i] = _clone(value[i]);
     }
@@ -5228,7 +5232,7 @@ function _clone(value) {
 function _findContextUrls(input, urls, replace, base) {
   var count = Object.keys(urls).length;
   if(_isArray(input)) {
-    for(var i in input) {
+    for(var i=0;i<input.length;i++) {
       _findContextUrls(input[i], urls, replace, base);
     }
     return (count < Object.keys(urls).length);
@@ -5345,7 +5349,7 @@ function _retrieveContextUrls(input, options, callback) {
 
     // retrieve URLs in queue
     var count = queue.length;
-    for(var i in queue) {
+    for(var i=0;i<queue.length;i++) {
       (function(url) {
         // check for context URL cycle
         if(url in cycles) {
@@ -5866,7 +5870,7 @@ Permutator = function(list) {
   this.done = false;
   // directional info for permutation algorithm
   this.left = {};
-  for(var i in list) {
+  for(var i=0;i<list.length;i++) {
     this.left[list[i]] = true;
   }
 };
@@ -5963,7 +5967,7 @@ else {
  */
 sha1.hash = function(nquads) {
   var md = sha1.create();
-  for(var i in nquads) {
+  for(var i=0;i<nquads.length;i++) {
     md.update(nquads[i]);
   }
   return md.digest();


### PR DESCRIPTION
Something like the following is needed to make jsonld.js run in IE8 (which, unfortunately, is still a reality in some environments).
1.  Outside of JSLD, assume that polyfills have been defined for `Array.forEach`, `Array.isArray`, `Object.keys`, etc.
2.  Inside JSLD, don't assume it's save to iterate through arrays with "var i in arrayName" (because this will pick up properties from the polyfill library)
3.  Inside JSLD, test more aggressively for `Object.definePropery` (because in IE8, this _exists_ but doesn't **work** for non-DOM nodes)

This pull request addresses (2) and (3); (1) is out of scope.

I wasn't totally clear in every instance which loops were over arrays vs. objects (and some were explicitly "agnostic").  Perhaps the best I can say is this PR doesn't break any tests that were passing in master :-)
