### PR TITLE
Fix _parseNQuads: blank node labels may start by [0-9]

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -5923,7 +5923,7 @@ if(!Object.keys) {
 function _parseNQuads(input) {
   // define partial regexes
   var iri = '(?:<([^:]+:[^>]*)>)';
-  var bnode = '(_:(?:[A-Za-z][A-Za-z0-9]*))';
+  var bnode = '(_:(?:[A-Za-z0-9]+))';
   var plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
   var datatype = '(?:\\^\\^' + iri + ')';
   var language = '(?:@([a-z]+(?:-[a-z0-9]+)*))';


### PR DESCRIPTION
Hi,

I had an issue parsing the nquads output from 'rdfstore-js' (results of a construct sparql query).
The issue is that they used blank nodes labels starting with a number (ex: "_:0")

However, from what I understand of http://www.w3.org/TR/n-quads/#grammar-production-BLANK_NODE_LABEL , it seems completely valid.

Mocha tests are still all passing...
