### PR TITLE
removed global leak by adding missing var to one of rval occurences

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -3321,7 +3321,7 @@ function _expandValue(activeCtx, activeProperty, value) {
     return value;
   }
 
-  rval = {};
+  var rval = {};
 
   // other type
   if(type !== null) {


### PR DESCRIPTION
we stumbled upon that when running mocha with `--check-leaks` in https://github.com/mcollina/levelgraph-jsonld/pull/17
