### PR TITLE
fix: js/Promise.js does not exists anymore, use es6-promise instead

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1044,7 +1044,7 @@ jsonld.promises = function() {
  */
 jsonld.promisify = function(op) {
   try {
-    var Promise = global.Promise || require('./Promise').Promise;
+    var Promise = global.Promise || require('es6-promise').Promise;
   }
   catch(e) {
     throw new Error('Unable to find a Promise implementation.');


### PR DESCRIPTION
This commit fix an error introduced by #57 and #56 when using node (or browserify):
- The file `js/Promise.js` no longer exists but is sometimes required by `jsonld.promisify()` 
- `js/Promise.js` can be replaced by `es6-promise`
