### PR TITLE
Correct documentation of documentLoader usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,13 @@ var customLoader = function(url, callback) {
         documentUrl: url // this is the actual context URL after redirects
       });
   }
-  nodeDocumentLoader(url, callback);
+  nodeDocumentLoader(url).
+    then(function(resp){
+      callback(null, resp);
+    }).
+    catch(function(err){
+      callback(err, null);
+    });
 };
 jsonld.documentLoader = customLoader;
 

--- a/README.md
+++ b/README.md
@@ -224,18 +224,12 @@ var customLoader = function(url, callback) {
         documentUrl: url // this is the actual context URL after redirects
       });
   }
-  // Call the underlining documentLoader using the node.js interface.  
+  // Call the underlining documentLoader using the callback API.
   nodeDocumentLoader(url, callback);
-  // In the browser (jsonld.documentLoaders.xhr() or jsonld.documentLoaders.jquery())
-  // the documentLoader returns a promise instead of taking a callback:
-  //
-  // nodeDocumentLoader(url).
-  //  then(function(resp){
-  //    callback(null, resp);
-  //  }).
-  //  catch(function(err){
-  //    callback(err, null);
-  //  });
+  // Notice that, by default, node.js document loader uses callbacks, but browser-based
+  // document loaders (xhr or jquery) return promises if these are supported (or polyfilled)
+  // in the browser. This behaviour can be controlled with the 'usePromise' option when
+  // constructing the document loader. For example: jsonld.documentLoaders.xhr({usePromise: false});
 };
 jsonld.documentLoader = customLoader;
 

--- a/README.md
+++ b/README.md
@@ -224,13 +224,18 @@ var customLoader = function(url, callback) {
         documentUrl: url // this is the actual context URL after redirects
       });
   }
-  nodeDocumentLoader(url).
-    then(function(resp){
-      callback(null, resp);
-    }).
-    catch(function(err){
-      callback(err, null);
-    });
+  // Call the underlining documentLoader using the node.js interface.  
+  nodeDocumentLoader(url, callback);
+  // In the browser (jsonld.documentLoaders.xhr() or jsonld.documentLoaders.jquery())
+  // the documentLoader returns a promise instead of taking a callback:
+  //
+  // nodeDocumentLoader(url).
+  //  then(function(resp){
+  //    callback(null, resp);
+  //  }).
+  //  catch(function(err){
+  //    callback(err, null);
+  //  });
 };
 jsonld.documentLoader = customLoader;
 


### PR DESCRIPTION
A small correction to the README.

At least on the browser (not sure if it is the same behaviour in node.js) the documentLoader returns a promise. Passing the callback does nothing.

