### PR TITLE
Also ignore pkginfo when doing a browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "util": "./browser/ignore.js",
     "crypto": "./browser/ignore.js",
     "url": "./browser/ignore.js",
-    "http": "./browser/ignore.js"
+    "http": "./browser/ignore.js",
+    "pkginfo": "./browser/ignore.js"
   }
 }


### PR DESCRIPTION
This seems to be necessary when using ```require("jsonld")``` in a project which builds a browser bundle using webpack.