### PR TITLE
Added passing headers as part of the options hash for node document loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ test-coverage:
 	./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- \
 		-u exports -R $(REPORTER) $(TESTS)
 
+test-local:
+	./node_modules/.bin/mocha
+
 clean:
 	rm -rf coverage
 
-.PHONY: test test-node test-browser test-local-node test-local-browser test-normalization-node test-normalization-browser test-coverage clean
+.PHONY: test test-node test-browser test-local-node test-local-browser test-normalization-node test-normalization-browser test-coverage test-local clean

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1736,6 +1736,8 @@ jsonld.documentLoaders.jquery = function($, options) {
  *            default.
  *          request: the object which will make the request, default is
  *            provided by request.js
+ *          headers: an array of headers which will be passed as request
+ *            headers for the requested document. Accept is not allowed.
  *          usePromise: true to use a promises API, false for a
  *            callback-continuation-style API; false by default.
  *

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1734,6 +1734,8 @@ jsonld.documentLoaders.jquery = function($, options) {
  *            false not to (default: true).
  *          maxRedirects: the maximum number of redirects to permit, none by
  *            default.
+ *          request: the object which will make the request, default is
+ *            provided by request.js
  *          usePromise: true to use a promises API, false for a
  *            callback-continuation-style API; false by default.
  *
@@ -1743,7 +1745,8 @@ jsonld.documentLoaders.node = function(options) {
   options = options || {};
   var strictSSL = ('strictSSL' in options) ? options.strictSSL : true;
   var maxRedirects = ('maxRedirects' in options) ? options.maxRedirects : -1;
-  var request = require('request');
+  var request = ('request' in options) ? options.request : require('request');
+  var acceptHeader = 'application/ld+json, application/json';
   var http = require('http');
   // TODO: disable cache until HTTP caching implemented
   //var cache = new jsonld.DocumentCache();
@@ -1753,6 +1756,13 @@ jsonld.documentLoaders.node = function(options) {
     return queue.wrapLoader(function(url) {
       return jsonld.promisify(loadDocument, url, []);
     });
+  }
+  var headers = options.headers || {};
+  if( 'Accept' in headers || 'accept' in headers ) {
+
+    throw new RangeError( 'Accept header may not be specified as an option' +
+      '; only "' + acceptHeader + '" is supported.' );
+
   }
   return queue.wrapLoader(function(url, callback) {
     loadDocument(url, [], callback);
@@ -1778,11 +1788,13 @@ jsonld.documentLoaders.node = function(options) {
     if(doc !== null) {
       return callback(null, doc);
     }
+    var headers = Object.assign(
+        { 'Accept': acceptHeader },
+        options.headers
+    );
     request({
       url: url,
-      headers: {
-        'Accept': 'application/ld+json, application/json'
-      },
+      headers: headers,
       strictSSL: strictSSL,
       followRedirect: false
     }, handleResponse);

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1788,10 +1788,8 @@ jsonld.documentLoaders.node = function(options) {
     if(doc !== null) {
       return callback(null, doc);
     }
-    var headers = Object.assign(
-        { 'Accept': acceptHeader },
-        options.headers
-    );
+    var headers = { 'Accept': acceptHeader };
+    for( var k in options.headers ) { headers[ k ] = options.headers[ k ]; }
     request({
       url: url,
       headers: headers,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "jsonld"
   ],
   "scripts": {
+    "test-local": "make test-local",
     "test-node": "make test-node",
     "test-browser": "make test-browser",
     "test": "make test",

--- a/test/node-document-loader-tests.js
+++ b/test/node-document-loader-tests.js
@@ -17,7 +17,7 @@ describe( "For the node.js document loader", function() {
 
 	};
 
-	describe( "When build with no options specified", function() {
+	describe( "When built with no options specified", function() {
 
 		var options = {};
 		it( "loading should work", function( callback ) {
@@ -28,6 +28,7 @@ describe( "For the node.js document loader", function() {
 		} );
 
 	} );
+
 	describe( "When built with no explicit headers", function() {
 
 		var options = { request: requestMock };

--- a/test/node-document-loader-tests.js
+++ b/test/node-document-loader-tests.js
@@ -1,0 +1,119 @@
+/**
+ * Local tests for the node.js document loader
+ *
+ * @author goofballLogic
+ */
+
+var jsonld = require( "../js/jsonld" );
+var assert = require( "assert" );
+
+describe( "For the node.js document loader", function() {
+
+	var documentLoaderType = "node";
+	var requestMock = function( options, callback ) {
+
+		requestMock.calls.push( [].slice.call( arguments, 0 ) ); // store these for later inspection
+		callback( null, { headers: {} }, "" );
+
+	};
+
+	describe( "When built with no explicit headers", function() {
+
+		var options = { request: requestMock };
+
+		it( "loading should pass just the ld Accept header", function( callback ) {
+
+			jsonld.useDocumentLoader( documentLoaderType, options );
+			requestMock.calls = [];
+			var iri = "http://some.thing.test.com/my-thing.jsonld";
+			jsonld.documentLoader( iri, e => {
+
+				if( e ) { callback( e ); }
+				else {
+
+					var actualOptions = ( requestMock.calls[ 0 ] || {} )[ 0 ] || {};
+					var actualHeaders = actualOptions.headers;
+					var expectedHeaders = { "Accept": "application/ld+json, application/json" };
+					assert.deepEqual( actualHeaders, expectedHeaders );
+					callback();
+
+				}
+
+			} );
+
+		} );
+
+	} );
+
+	describe( "When built using options containing a headers object", function() {
+
+		var options = { request: requestMock };
+		options.headers = {
+
+			"x-test-header-1": "First value",
+			"x-test-two": 2.34,
+			"Via": "1.0 fred, 1.1 example.com (Apache/1.1)",
+			"Authorization": "Bearer d783jkjaods9f87o83hj"
+
+		};
+
+		it( "loading should pass the headers through on the request", function( callback ) {
+
+			jsonld.useDocumentLoader( documentLoaderType, options );
+			requestMock.calls = [];
+			var iri = "http://some.thing.test.com/my-thing.jsonld";
+			jsonld.documentLoader( iri, e => {
+
+				if( e ) { callback( e ); }
+				else {
+
+					var actualOptions = ( requestMock.calls[ 0 ] || {} )[ 0 ] || {};
+					var actualHeaders = actualOptions.headers;
+					var expectedHeaders = Object.assign(
+
+						{ "Accept": "application/ld+json, application/json" },
+						options.headers
+
+					);
+					assert.deepEqual( actualHeaders, expectedHeaders );
+					callback();
+
+				}
+
+			} );
+
+		} );
+
+	} );
+
+	describe( "When built using headers that already contain an Accept header", function() {
+
+		var options = { request: requestMock };
+		options.headers = {
+
+			"x-test-header-3": "Third value",
+			"Accept": "video/mp4"
+
+		};
+
+		it( "constructing the document loader should fail", function() {
+
+			var expectedMessage = "Accept header may not be specified as an option; only \"application/ld+json, application/json\" is supported.";
+			assert.throws(
+
+				jsonld.useDocumentLoader.bind( jsonld, documentLoaderType, options ),
+				err => {
+
+					assert.ok( err instanceof RangeError, "A range error should be thrown" );
+					assert.equal( err.message, expectedMessage );
+					return true;
+
+				}
+
+			);
+
+		} );
+
+	} );
+
+} );

--- a/test/node-document-loader-tests.js
+++ b/test/node-document-loader-tests.js
@@ -17,6 +17,17 @@ describe( "For the node.js document loader", function() {
 
 	};
 
+	describe( "When build with no options specified", function() {
+
+		var options = {};
+		it( "loading should work", function( callback ) {
+
+			jsonld.useDocumentLoader( documentLoaderType );
+			jsonld.expand( "http://schema.org/", callback );
+
+		} );
+
+	} );
 	describe( "When built with no explicit headers", function() {
 
 		var options = { request: requestMock };


### PR DESCRIPTION
0. node document loader can now accept "headers" as part of the options object.
    0. if `Accept` or `accept` are specified as part of headers, a `RangeError` is thrown specifying that only 
    `"Accept header may not be specified as an option; only "application/ld+json, application/json" is supported"`
    0. if `Accept` or `accept` are not specified, or the options object isn't specified, the default header of `application/ld_json, application/json` is passed
0. To make these changes more robust, I've added mocha tests in /test:
    0. To run local tests (ones that aren't testing the JSON-LD algorithms), use any of the following:
        - `npm run test-local`
        - `make test-local`
        - `mocha`
0. **[ N.B. side-effect ]**: to allow for efficient testing, I've added a facility to inject the "request" object as part of the options object, so that one can mock the interface of request.js. The corollary is that this facility could be used to inject one's own implementation of request.js at run-time. To avoid this we would need to spin up a local service rather than mocking.


  