### PR TITLE
Bug/support nquads

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ jsonld.fromRDF(nquads, {format: 'application/nquads'}, function(err, doc) {
   // doc is JSON-LD
 });
 
+// serialize a document to N-Quads (RDF)
+jsonld.toRDF(doc, {format: 'application/n-quads'}, function(err, nquads) {
+  // nquads is a string of nquads
+});
+
+// deserialize N-Quads (RDF) to JSON-LD
+jsonld.fromRDF(nquads, {format: 'application/n-quads'}, function(err, doc) {
+  // doc is JSON-LD
+});
+
 // register a custom async-callback-based RDF parser
 jsonld.registerRDFParser = function(contentType, function(input, callback) {
   // parse input to a jsonld.js RDF dataset object...

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ jsonld.toRDF(doc, {format: 'application/n-quads'}, function(err, nquads) {
 });
 
 // deserialize N-Quads (RDF) to JSON-LD
-jsonld.fromRDF(nquads, {format: 'application/n-quads'}, function(err, doc) {
+jsonld.fromRDF(nquads, {format: 'application/n-quads', useStandardNQuadsType: true}, function(err, doc) {
   // doc is JSON-LD
 });
 

--- a/README.md
+++ b/README.md
@@ -156,22 +156,12 @@ jsonld.normalize(doc, {
 });
 
 // serialize a document to N-Quads (RDF)
-jsonld.toRDF(doc, {format: 'application/nquads'}, function(err, nquads) {
-  // nquads is a string of nquads
-});
-
-// deserialize N-Quads (RDF) to JSON-LD
-jsonld.fromRDF(nquads, {format: 'application/nquads'}, function(err, doc) {
-  // doc is JSON-LD
-});
-
-// serialize a document to N-Quads (RDF)
 jsonld.toRDF(doc, {format: 'application/n-quads'}, function(err, nquads) {
   // nquads is a string of nquads
 });
 
 // deserialize N-Quads (RDF) to JSON-LD
-jsonld.fromRDF(nquads, {format: 'application/n-quads', useStandardNQuadsType: true}, function(err, doc) {
+jsonld.fromRDF(nquads, {format: 'application/n-quads'}, function(err, doc) {
   // doc is JSON-LD
 });
 

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -756,9 +756,9 @@ jsonld.objectify = function(input, ctx, options, callback) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [inputFormat] the format if input is not JSON-LD:
- *            'appilcation/n-quads' for N-Quads
+ *            'appilcation/n-quads' for N-Quads.
  *          [format] the format if output is a string:
- *            'appilcation/n-quads' for N-Quads
+ *            'appilcation/n-quads' for N-Quads.
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
  * @param callback(err, normalized) called once the operation completes.
  */
@@ -787,8 +787,13 @@ jsonld.normalize = function(input, options, callback) {
     options.documentLoader = jsonld.loadDocument;
   }
 
-  if('inputFormat' in options) {
-    if(options.inputFormat !== 'application/n-quads') {
+  var opts = _clone(options);
+
+  if('inputFormat' in opts) {
+    if(opts.inputFormat.indexOf('application/nquads') != -1) {
+      opts.inputFormat = 'application/n-quads';
+    }
+    if(opts.inputFormat !== 'application/n-quads') {
       return callback(new JsonLdError(
         'Unknown normalization input format.',
         'jsonld.NormalizeError'));
@@ -798,7 +803,6 @@ jsonld.normalize = function(input, options, callback) {
     new Processor().normalize(parsedInput, options, callback);
   } else {
     // convert to RDF dataset then do normalization
-    var opts = _clone(options);
     delete opts.format;
     opts.produceGeneralizedRdf = false;
     jsonld.toRDF(input, opts, function(err, dataset) {

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -756,9 +756,9 @@ jsonld.objectify = function(input, ctx, options, callback) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [inputFormat] the format if input is not JSON-LD:
- *            'application/nquads' or 'application/n-quads' for N-Quads.
+ *            'appilcation/n-quads' or 'application/n-quads' for N-Quads.
  *          [format] the format if output is a string:
- *            'application/nquads' or 'application/n-quads' for N-Quads.
+ *            'appilcation/n-quads' or 'application/n-quads' for N-Quads.
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
  * @param callback(err, normalized) called once the operation completes.
  */
@@ -788,7 +788,7 @@ jsonld.normalize = function(input, options, callback) {
   }
 
   if('inputFormat' in options) {
-    if((options.inputFormat !== 'application/nquads') || (options.inputFormat !== 'application/n-quads'))  {
+    if(options.inputFormat !== 'application/n-quads') {
       return callback(new JsonLdError(
         'Unknown normalization input format.',
         'jsonld.NormalizeError'));
@@ -820,9 +820,7 @@ jsonld.normalize = function(input, options, callback) {
  *          format option or an RDF dataset to convert.
  * @param [options] the options to use:
  *          [format] the format if dataset param must first be parsed:
- *            'application/nquads' for N-Quads (default).
- *          [useStandardNQuadsType] the format of N-Quads
- *            (default: false)
+ *            'application/n-quads' for N-Quads (default).
  *          [rdfParser] a custom RDF-parser to use to parse the dataset.
  *          [useRdfType] true to use rdf:type, false to use @type
  *            (default: false).
@@ -852,18 +850,10 @@ jsonld.fromRDF = function(dataset, options, callback) {
     options.useNativeTypes = false;
   }
 
-  if (!('useStandardNQuadsType' in options)){
-    options.useStandardNQuadsType = false;
-  }
-
   if(!('format' in options) && _isString(dataset)) {
-    // set default format to nquads
+    // set default format to n-quads
     if(!('format' in options)) {
-      if (!options.useStandardNQuadsType){
-        options.format = 'application/nquads';
-      } else {
-        options.format = 'application/n-quads';
-      }
+      options.format = 'application/n-quads';
     }
   }
 
@@ -928,7 +918,7 @@ jsonld.fromRDF = function(dataset, options, callback) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [format] the format to use to output a string:
- *            'application/nquads' for N-Quads.
+ *            'appilcation/n-quads' for N-Quads.
  *          [produceGeneralizedRdf] true to output generalized RDF, false
  *            to produce only standard RDF (default: false).
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
@@ -969,7 +959,7 @@ jsonld.toRDF = function(input, options, callback) {
       // output RDF dataset
       dataset = Processor.prototype.toRDF(expanded, options);
       if(options.format) {
-        if((options.format === 'application/nquads') || (options.format === 'application/n-quads')) {
+        if(options.format === 'appilcation/n-quads') {
           return callback(null, _toNQuads(dataset));
         }
         throw new JsonLdError(
@@ -4015,7 +4005,7 @@ Normalize.prototype.main = function(dataset, callback) {
 
   // handle invalid output format
   if(self.options.format) {
-    if(self.options.format !== 'application/nquads') {
+    if(self.options.format !== 'appilcation/n-quads') {
       return callback(new JsonLdError(
         'Unknown output format.',
         'jsonld.UnknownFormat', {format: self.options.format}));
@@ -4227,7 +4217,7 @@ Normalize.prototype.main = function(dataset, callback) {
           normalized.sort();
 
           // 8) Return the normalized dataset.
-          if((self.options.format === 'application/nquads') || (self.options.format === 'application/n-quads')) {
+          if(self.options.format === 'appilcation/n-quads') {
             result = normalized.join('');
             return callback();
           }
@@ -7032,7 +7022,6 @@ function _parseNQuads(input) {
 }
 
 // register the N-Quads RDF parser
-jsonld.registerRDFParser('application/nquads', _parseNQuads);
 jsonld.registerRDFParser('application/n-quads', _parseNQuads);
 
 /**

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -790,7 +790,7 @@ jsonld.normalize = function(input, options, callback) {
   var opts = _clone(options);
 
   if('inputFormat' in opts) {
-    if(opts.inputFormat.indexOf('application/nquads') != -1) {
+    if(opts.inputFormat.indexOf('application/nquads') === -1) {
       opts.inputFormat = 'application/n-quads';
     }
     if(opts.inputFormat !== 'application/n-quads') {
@@ -922,7 +922,7 @@ jsonld.fromRDF = function(dataset, options, callback) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [format] the format to use to output a string:
- *            'appilcation/n-quads' for N-Quads.
+ *            'appilcation/nquads' for N-Quads.
  *          [produceGeneralizedRdf] true to output generalized RDF, false
  *            to produce only standard RDF (default: false).
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
@@ -963,7 +963,7 @@ jsonld.toRDF = function(input, options, callback) {
       // output RDF dataset
       dataset = Processor.prototype.toRDF(expanded, options);
       if(options.format) {
-        if(options.format === 'appilcation/n-quads') {
+        if(options.format === 'appilcation/nquads') {
           return callback(null, _toNQuads(dataset));
         }
         throw new JsonLdError(
@@ -4009,7 +4009,7 @@ Normalize.prototype.main = function(dataset, callback) {
 
   // handle invalid output format
   if(self.options.format) {
-    if(self.options.format !== 'appilcation/n-quads') {
+    if(self.options.format !== 'appilcation/nquads') {
       return callback(new JsonLdError(
         'Unknown output format.',
         'jsonld.UnknownFormat', {format: self.options.format}));
@@ -4221,7 +4221,7 @@ Normalize.prototype.main = function(dataset, callback) {
           normalized.sort();
 
           // 8) Return the normalized dataset.
-          if(self.options.format === 'appilcation/n-quads') {
+          if(self.options.format === 'appilcation/nquads') {
             result = normalized.join('');
             return callback();
           }
@@ -7026,6 +7026,7 @@ function _parseNQuads(input) {
 }
 
 // register the N-Quads RDF parser
+jsonld.registerRDFParser('application/nquads', _parseNQuads);
 jsonld.registerRDFParser('application/n-quads', _parseNQuads);
 
 /**

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -859,7 +859,7 @@ jsonld.fromRDF = function(dataset, options, callback) {
   if(!('format' in options) && _isString(dataset)) {
     // set default format to nquads
     if(!('format' in options)) {
-      if (!useStandardNQuadsType){
+      if (!options.useStandardNQuadsType){
         options.format = 'application/nquads';
       } else {
         options.format = 'application/n-quads';

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -756,9 +756,9 @@ jsonld.objectify = function(input, ctx, options, callback) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [inputFormat] the format if input is not JSON-LD:
- *            'appilcation/n-quads' or 'application/n-quads' for N-Quads.
+ *            'appilcation/n-quads'
  *          [format] the format if output is a string:
- *            'appilcation/n-quads' or 'application/n-quads' for N-Quads.
+ *            'appilcation/n-quads'
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
  * @param callback(err, normalized) called once the operation completes.
  */

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -756,9 +756,9 @@ jsonld.objectify = function(input, ctx, options, callback) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [inputFormat] the format if input is not JSON-LD:
- *            'appilcation/n-quads'
+ *            'appilcation/n-quads' for N-Quads
  *          [format] the format if output is a string:
- *            'appilcation/n-quads'
+ *            'appilcation/n-quads' for N-Quads
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
  * @param callback(err, normalized) called once the operation completes.
  */


### PR DESCRIPTION
Hey, 

As pointed out in #141, This PR intends to support both `application/nquads` and `application/n-quads` in jsonld.js.

There are a few things, that I wanted to know
- Should we still support `application/nquads`?
- In this PR I am using `options.useStandardNQuadsType` and if the user passes `true` then only `application/n-quads` formatting is done. Should I make this behaviour by default? And also should I change the variable name to something more generic?
