### PR TITLE
fixed the regex for bnodes when parsing n-quads.

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -6911,7 +6911,7 @@ if(!Object.keys) {
 function _parseNQuads(input) {
   // define partial regexes
   var iri = '(?:<([^:]+:[^>]*)>)';
-  var bnode = '(_:(?:[A-Za-z0-9]+))';
+  var bnode = '(_:(?:[A-Za-z0-9_]+))';
   var plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
   var datatype = '(?:\\^\\^' + iri + ')';
   var language = '(?:@([a-z]+(?:-[a-z0-9]+)*))';


### PR DESCRIPTION
Actually only a partial fix to support '_' in the bnode label as per specification:

http://www.w3.org/TR/n-quads/#BNodes

```
The characters _ and digits may appear anywhere in a blank node label.
```

This causes issues on rdflib also which is utilising jsonld.js for json-ld serialisation.