### PR TITLE
Fix the Mixed Content mess in XHR Requests

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1687,7 +1687,8 @@ jsonld.documentLoaders.jquery = function($, options) {
       },
       // ensure Accept header is very specific for JSON-LD/JSON
       headers: {
-        'Accept': 'application/ld+json, application/json'
+        'Accept': 'application/ld+json, application/json',
+        'Upgrade-Insecure-Requests': '1'
       },
       dataType: 'json',
       crossDomain: true,
@@ -1964,6 +1965,7 @@ jsonld.documentLoaders.xhr = function(options) {
         {contextUrl: null, documentUrl: url, document: null});
     };
     req.open('GET', url, true);
+    req.setRequestHeader('Upgrade-Insecure-Requests', '1');
     req.setRequestHeader('Accept', 'application/ld+json, application/json');
     req.send();
   }


### PR DESCRIPTION
Using https://www.w3.org/TR/upgrade-insecure-requests/

Added to the two browser-based document loaders: jquery & xhr

This avoids the Mixed Content errors when requesting non-https URLs which are also available over https. Fixes the security situation without changing the names...more or less.

Hope it's helpful!
🎩 