### PR TITLE
Revert "Fix the Mixed Content mess in XHR Requests"

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1687,8 +1687,7 @@ jsonld.documentLoaders.jquery = function($, options) {
       },
       // ensure Accept header is very specific for JSON-LD/JSON
       headers: {
-        'Accept': 'application/ld+json, application/json',
-        'Upgrade-Insecure-Requests': '1'
+        'Accept': 'application/ld+json, application/json'
       },
       dataType: 'json',
       crossDomain: true,
@@ -1965,7 +1964,6 @@ jsonld.documentLoaders.xhr = function(options) {
         {contextUrl: null, documentUrl: url, document: null});
     };
     req.open('GET', url, true);
-    req.setRequestHeader('Upgrade-Insecure-Requests', '1');
     req.setRequestHeader('Accept', 'application/ld+json, application/json');
     req.send();
   }


### PR DESCRIPTION
Reverts digitalbazaar/jsonld.js#165

It has been determined this patch does not work as intended and can cause breakage.

Browsers can still block a request due to mixed content rules which causes this header to never even reach a target server.

When using with a non-secure site the header can cause issues with some sites due to CORS processing rules.  In particular, it currently does not work on www.w3.org.