### PR TITLE
Self-provided test suite and assert @version correctly when specified (port of #179 to 0.5.x)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TESTS = tests/test.js
 LOCAL_TESTS = test/*.js
 REPORTER = spec
+JSONLD_TEST_SUITE=node_modules/json-ld-test-suite
 
 all:
 

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -5731,6 +5731,15 @@ function _createTermDefinition(activeCtx, localCtx, term, defined) {
       {code: 'keyword redefinition', context: localCtx, term: term});
   }
 
+  if(term === '@version') {
+    if(value !== 1.1) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; version must be 1.1 if specified',
+        'jsonld.SyntaxError',
+        {code: 'invalid @version value', context: localCtx});
+    }
+  }
+
   if(term === '') {
     throw new JsonLdError(
       'Invalid JSON-LD syntax; a term cannot be an empty string.',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "main": "lib/jsonld.js",
   "dependencies": {
     "es6-promise": "^2.0.0",
+    "json-ld-test-suite": "^1.0.1",
     "pkginfo": "~0.4.0",
     "request": "^2.61.0",
     "xmldom": "0.1.19"


### PR DESCRIPTION
This does not get CI working, as the tests (obviously) do not pass yet for this branch. However, it does make it possible to see real status in CI.
.

- I published the json-ld.org test suite as an npm module. I'm happy to pass on the keys to that npm package for updates if that is a concern; Also happy to maintain that going forward, I don't anticipate a lot of work there, but won't be making it a priority for my work unless someone wants to poke me about it
- I added code to conform to tp003 and tp006 tests, asserting that version is `1.1` if it is specified at all.