### PR TITLE
Allow valid accept headers in document loader options

### DIFF
--- a/test/buildHeaders.test.js
+++ b/test/buildHeaders.test.js
@@ -1,0 +1,103 @@
+var jsonld = require('../js/jsonld');
+var assert = require('assert');
+
+describe('Build a valid header object from pre-defined headers', function() {
+
+  describe('When built with 2 accept headers', function() {
+    var headers = {
+      'Accept': 'application/json',
+      'accept': 'application/ld+json, application/json'
+    };
+
+
+    it('should fail', function() {
+      assert.throws(
+        jsonld.buildHeaders.bind(null, headers),
+        function(err) {
+          assert.ok(err instanceof RangeError, 'A range error should be thrown');
+          assert.equal(err.message, 'Accept header may be specified only once.');
+
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('When built with no explicit headers', function() {
+    var headers = {};
+    it(
+      'the "Accept" header should default to "application/ld+json, application/json"',
+      function() {
+        var actualHeaders = jsonld.buildHeaders(headers);
+        assert.deepEqual(actualHeaders, {
+          'Accept': 'application/ld+json, application/json'
+        });
+      }
+    );
+  });
+
+  describe('When built with custom headers', function() {
+    var headers = {
+      'Authorization': 'Bearer d783jkjaods9f87o83hj'
+    };
+    it('the custom headers should be preserved', function() {
+      var actualHeaders = jsonld.buildHeaders(headers);
+      assert.deepEqual(actualHeaders, {
+        'Authorization': 'Bearer d783jkjaods9f87o83hj',
+        'Accept': 'application/ld+json, application/json'
+      });
+    });
+  });
+
+  describe('When built with an accept header equal to the default accept header value', function() {
+    var headers = {
+      'Accept': 'application/ld+json, application/json'
+    };
+    it(
+      'the accept header should remain unchanged',
+      function() {
+        var actualHeaders = jsonld.buildHeaders(headers);
+        assert.deepEqual(actualHeaders, headers);
+      }
+    );
+  });
+
+  describe('When built with a valid accept headers with extra acceptations', function() {
+    var headers = {
+      'Accept': 'application/ld+json, application/json, text/html'
+    };
+    it(
+      'the accept header should remain unchanged',
+      function() {
+        var actualHeaders = jsonld.buildHeaders(headers);
+        assert.deepEqual(actualHeaders, headers);
+      }
+    );
+  });
+
+  describe('When built with an invalid accept header', function() {
+    var possibleInvalidHeaders = [
+      { 'Accept': 'text/html' },
+      { 'Accept': 'application/ld+json, application/jsonbourne' },
+      { 'Accept': 'application/ld+json application/json' }
+    ];
+
+    for (var i in possibleInvalidHeaders) {
+      console.log(possibleInvalidHeaders[i]);
+      it('should fail', function() {
+        assert.throws(
+          jsonld.buildHeaders.bind(null, possibleInvalidHeaders[i]),
+          function(err) {
+            assert.ok(err instanceof RangeError, 'A range error should be thrown');
+            assert.equal(
+              err.message,
+              'Accept header must contains "application/ld+json, application/json".'
+            );
+
+            return true;
+          }
+        );
+      });
+    }
+  });
+});

--- a/test/node-document-loader-tests.js
+++ b/test/node-document-loader-tests.js
@@ -78,7 +78,7 @@ describe('For the node.js document loader', function() {
     });
   });
 
-  describe('When built using headers that already contain an Accept header', function() {
+  describe('When built using headers that already contain an invalid Accept header', function() {
     var options = {request: requestMock};
     options.headers = {
       'x-test-header-3': 'Third value',
@@ -86,7 +86,7 @@ describe('For the node.js document loader', function() {
     };
 
     it('constructing the document loader should fail', function() {
-      var expectedMessage = 'Accept header may not be specified as an option; only "application/ld+json, application/json" is supported.';
+      var expectedMessage = 'Accept header must contains "application/ld+json, application/json".';
       assert.throws(
         jsonld.useDocumentLoader.bind(jsonld, documentLoaderType, options),
         function(err) {


### PR DESCRIPTION
Hi guys,

Here is a feature that was previously mention in #176 
> The current implementation is far too restrictive on this accept header. The RangeError exception should only be raised when the accept header doesn't contain application/ld+json nor application/json.

>This way it could be overridden for more exotic things like application/ld+json, text/html, application/json, that would still be valid.

The point here is to allow valid headers to be used, because at the moment, even if the user specify exactly the default value (application/ld+json,  application/json) the `RangeError` is raised nonetheless.

Also, even if the `buildHeaders` function wasn't meant to be exposed, at the moment this is only way to unit test portions of code as there are no builds tools to allow to split things up and require them only where needed. By the way, is there any news/plans on this?

Anyway, what do you think of this feature?