### PR TITLE
Fix compact-0073 test case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Update url parser to remove default ports from URLs.
 - Skip spec version 1.1 tests.
 
+### Fixed
+- Fix compact-0073 test case.
+
 ## 0.4.12 - 2017-04-24
 
 ### Fixed

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -5498,7 +5498,11 @@ function _compactIri(activeCtx, iri, value, relativeTo, reverse) {
   // if term is a keyword, it can only be compacted to a simple alias
   if(_isKeyword(iri)) {
     if(iri in inverseCtx) {
-      return inverseCtx[iri]['@none']['@type']['@none'];
+      var type = inverseCtx[iri]['@none']['@type'];
+      if('@id' in type) {
+        return type['@id'];
+      }
+      return type['@none'];
     }
     return iri;
   }


### PR DESCRIPTION
Related commit causing regression:
https://github.com/digitalbazaar/jsonld.js/commit/07e9c06dcae3ebb924a0eba6b5fcd9a76b702da2

Test case (added after the above commit):
https://github.com/json-ld/json-ld.org/commit/9268a3dfad927c70ccb6f1917697d0ac9885d7a5

This is a guess that fixes the test case.  Please review this patch as I'm not familiar with how this code and the inverseCtx works and the fix may need to be elsewhere.