### PR TITLE
simplify fetching of package version

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -8177,9 +8177,7 @@ if(_nodejs) {
   };
 
   // expose version
-  var _module = {exports: {}, filename: __dirname};
-  require('pkginfo')(_module, 'version');
-  jsonld.version = _module.exports.version;
+  jsonld.version = require('../package.json').version
 }
 
 // end of jsonld API factory


### PR DESCRIPTION
This removes the pkginfo dependency to determine the version of the package. 
Using webpack to build my node packages otherwise gives me `package.json` not found.

Addresses #168 and and related to #152 