### PR TITLE
Do not promisify `xhr` loader.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "amd": true,
+    "browser": true,
+    "jquery": true
+  },
+  "rules": {
+    "indent": ["error", 2, {"outerIIFEBody": 0}]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ define(['jsonld'], function(jsonld) { ... });
 <!-- For legacy browsers include a Promise polyfill like
   es6-promise before including jsonld.js -->
 <script src="//cdn.jsdelivr.net/g/es6-promise@1.0.0"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jsonld/0.4.12/jsonld.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jsonld/0.4.12/jsonld.min.js"></script>
 ```
+See https://cdnjs.com/libraries/jsonld for the the latest available cdnjs version.
 
 ### JSPM
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ define(['jsonld'], function(jsonld) { ... });
 <!-- For legacy browsers include a Promise polyfill like
   es6-promise before including jsonld.js -->
 <script src="//cdn.jsdelivr.net/g/es6-promise@1.0.0"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jsonld/0.3.15/jsonld.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jsonld/0.4.12/jsonld.js"></script>
 ```
 
 ### JSPM

--- a/README.md
+++ b/README.md
@@ -228,11 +228,8 @@ var CONTEXTS = {
 // grab the built-in node.js doc loader
 var nodeDocumentLoader = jsonld.documentLoaders.node();
 // or grab the XHR one: jsonld.documentLoaders.xhr()
-// or grab the jquery one: jsonld.documentLoaders.jquery()
 
 // change the default document loader using the callback API
-// (you can also do this using the promise-based API, return a promise instead
-// of using a callback)
 var customLoader = function(url, callback) {
   if(url in CONTEXTS) {
     return callback(
@@ -244,11 +241,6 @@ var customLoader = function(url, callback) {
   }
   // call the underlining documentLoader using the callback API.
   nodeDocumentLoader(url, callback);
-  /* Note: By default, the node.js document loader uses a callback, but
-  browser-based document loaders (xhr or jquery) return promises if they
-  are supported (or polyfilled) in the browser. This behavior can be
-  controlled with the 'usePromise' option when constructing the document
-  loader. For example: jsonld.documentLoaders.xhr({usePromise: false}); */
 };
 jsonld.documentLoader = customLoader;
 

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -289,7 +289,7 @@ jsonld.expand = function(input, options, callback) {
               code: 'loading document failed',
               cause: ex,
               remoteDoc: remoteDoc
-          }));
+            }));
         }
         expand(remoteDoc);
       };
@@ -509,7 +509,7 @@ jsonld.frame = function(input, frame, options, callback) {
               code: 'loading document failed',
               cause: ex,
               remoteDoc: remoteDoc
-          }));
+            }));
         }
         doFrame(remoteDoc);
       };
@@ -1471,7 +1471,8 @@ jsonld.setImmediate = _setImmediate ? _delay : jsonld.nextTick;
 /**
  * Parses a link header. The results will be key'd by the value of "rel".
  *
- * Link: <http://json-ld.org/contexts/person.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+ * Link: <http://json-ld.org/contexts/person.jsonld>;
+ * rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
  *
  * Parses as: {
  *   'http://www.w3.org/ns/json-ld#context': {
@@ -1655,7 +1656,8 @@ var _defaults = {
 };
 
 /**
- * Build an headers object from custom headers and assert `accept` header isn't overridden.
+ * Build an headers object from custom headers and assert `accept`
+ * header isn't overridden.
  *
  * @param {Object} optionsHeaders an object (map) of headers
  *          with key as header name and value as header value.
@@ -1675,7 +1677,7 @@ function buildHeaders(optionsHeaders) {
   }
 
   var headers = {'Accept': _defaults.headers.accept};
-  for(var k in optionsHeaders) { headers[k] = optionsHeaders[k]; }
+  for(var k in optionsHeaders) {headers[k] = optionsHeaders[k];}
 
   return headers;
 }
@@ -2379,7 +2381,7 @@ if(_nodejs) {
       DOCUMENT_NODE: 9,
       DOCUMENT_TYPE_NODE: 10,
       DOCUMENT_FRAGMENT_NODE: 11,
-      NOTATION_NODE:12
+      NOTATION_NODE: 12
     };
   }
 }
@@ -3543,8 +3545,8 @@ function _expandLanguageMap(languageMap) {
     for(var vi = 0; vi < val.length; ++vi) {
       var item = val[vi];
       if(item === null) {
-          // null values are allowed (8.5) but ignored (3.1)
-          continue;
+        // null values are allowed (8.5) but ignored (3.1)
+        continue;
       }
       if(!_isString(item)) {
         throw new JsonLdError(
@@ -4110,7 +4112,7 @@ Normalize.prototype.main = function(dataset, callback) {
       var simple = true;
 
       // 5) While simple is true, issue canonical identifiers for blank nodes:
-      self.whilst(function() { return simple; }, function(callback) {
+      self.whilst(function() {return simple;}, function(callback) {
         // 5.1) Set simple to false.
         simple = false;
 
@@ -4433,9 +4435,9 @@ Normalize.prototype.hashNDegreeQuads = function(id, issuer, callback) {
 
         // 5.4) For each permutation of blank node list:
         var permutator = new Permutator(hashToRelated[hash]);
-        self.whilst(
-          function() { return permutator.hasNext(); },
-          function(nextPermutation) {
+        self.whilst(function() {
+          return permutator.hasNext();
+        }, function(nextPermutation) {
           var permutation = permutator.next();
 
           // 5.4.1) Create a copy of issuer, issuer copy.

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -1890,10 +1890,7 @@ jsonld.documentLoaders.xhr = function(options) {
 
 /**
  * Assigns the default document loader for external document URLs to a built-in
- * default. Supported types currently include: 'jquery' and 'node'.
- *
- * To use the jquery document loader, the first parameter must be a reference
- * to the main jquery object.
+ * default. Supported types currently include: 'node' and 'xhr'.
  *
  * @param type the type to set.
  * @param [params] the parameters required to use the document loader.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jshint": "^2.9.1",
     "mocha": "^3.3.0",
     "mocha-phantomjs": "~3.5.6",
-    "phantomjs": "~1.9.18"
+    "phantomjs-prebuilt": "~2.1.14"
   },
   "engines": {
     "node": "*"

--- a/tests/test.js
+++ b/tests/test.js
@@ -655,16 +655,18 @@ function getEnv() {
  * @return the document loader.
  */
 function createDocumentLoader(test) {
-  var base = 'http://json-ld.org/test-suite';
+  var baseRegex = /^(http|https):\/\/json-ld.org\/test-suite\//;
+  var base;
   var loader = jsonld.documentLoader;
   var localLoader = function(url, callback) {
     // always load remote-doc tests remotely in node
     if(_nodejs && test.manifest.name === 'Remote document') {
       return loader(url, callback);
     }
-
-    var idx = url.indexOf(base);
-    if(idx === 0 || url.indexOf(':') === -1) {
+    var m = url.match(baseRegex);
+    // no match must be empty string because `base.length` is used later
+    base = m ? m[0] : '';
+    if(base || url.indexOf(':') === -1) {
       // attempt to load official test-suite files or relative URLs locally
       var rval;
       try {


### PR DESCRIPTION
This patch works in e2e tests that perform front-end and back-end jsonld operations.

Depends on: https://github.com/digitalbazaar/bedrock-angular/pull/24