### PR TITLE
Update jsonld browser + script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ define(['jsonld'], function(jsonld) { ... });
 <!-- For legacy browsers include a Promise polyfill like
   es6-promise before including jsonld.js -->
 <script src="//cdn.jsdelivr.net/g/es6-promise@1.0.0"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jsonld/0.3.15/jsonld.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jsonld/0.4.12/jsonld.js"></script>
 ```
 
 ### JSPM


### PR DESCRIPTION
The jsonld browser + script tag yielded a different canonical form than when I used the library directly. I confirmed there is a later version that yields the expected results. Updating so others don't run into this as well.