### PR TITLE
Fix _removeDotSegments.

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -6116,13 +6116,11 @@ function _prependBase(base, iri) {
         var path = base.path;
 
         // append relative path to the end of the last directory from base
-        if(rel.path !== '') {
-          path = path.substr(0, path.lastIndexOf('/') + 1);
-          if(path.length > 0 && path.substr(-1) !== '/') {
-            path += '/';
-          }
-          path += rel.path;
+        path = path.substr(0, path.lastIndexOf('/') + 1);
+        if(path.length > 0 && path.substr(-1) !== '/') {
+          path += '/';
         }
+        path += rel.path;
 
         transform.path = path;
       }

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -8131,35 +8131,49 @@ jsonld.url.parse = function(str, parser) {
  * @param hasAuthority true if the URL has an authority, false if not.
  */
 function _removeDotSegments(path, hasAuthority) {
-  var rval = '';
+  // RFC 3986 5.2.4 (reworked)
 
-  if(path.indexOf('/') === 0) {
-    rval = '/';
+  // empty path shortcut
+  if(path.length === 0) {
+    return '';
   }
 
-  // RFC 3986 5.2.4 (reworked)
   var input = path.split('/');
   var output = [];
+
   while(input.length > 0) {
-    if(input[0] === '.' || (input[0] === '' && input.length > 1)) {
-      input.shift();
-      continue;
-    }
-    if(input[0] === '..') {
-      input.shift();
-      if(hasAuthority ||
-        (output.length > 0 && output[output.length - 1] !== '..')) {
-        output.pop();
-      } else {
-        // leading relative URL '..'
-        output.push('..');
+    var next = input.shift();
+    var done = input.length === 0;
+
+    if(next === '.') {
+      if(done) {
+        // ensure output has trailing /
+        output.push('');
       }
       continue;
     }
-    output.push(input.shift());
+
+    if(next === '..') {
+      output.pop();
+      if(done) {
+        // ensure output has trailing /
+        output.push('');
+      }
+      continue;
+    }
+
+    output.push(next);
   }
 
-  return rval + output.join('/');
+  // ensure output has leading /
+  if(output.length > 0 && output[0] !== '') {
+    output.unshift('');
+  }
+  if(output.length === 1 && output[0] === '') {
+    return '/';
+  }
+
+  return output.join('/');
 }
 
 if(_nodejs) {

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -6130,7 +6130,7 @@ function _prependBase(base, iri) {
 
   if(rel.path !== '') {
   // remove slashes and dots in path
-    transform.path = _removeDotSegments(transform.path, !!transform.authority);
+    transform.path = _removeDotSegments(transform.path);
   }
 
   // construct URL
@@ -8120,7 +8120,7 @@ jsonld.url.parse = function(str, parser) {
     parsed.port = null;
   }
 
-  parsed.normalizedPath = _removeDotSegments(parsed.path, !!parsed.authority);
+  parsed.normalizedPath = _removeDotSegments(parsed.path);
   return parsed;
 };
 
@@ -8128,9 +8128,8 @@ jsonld.url.parse = function(str, parser) {
  * Removes dot segments from a URL path.
  *
  * @param path the path to remove dot segments from.
- * @param hasAuthority true if the URL has an authority, false if not.
  */
-function _removeDotSegments(path, hasAuthority) {
+function _removeDotSegments(path) {
   // RFC 3986 5.2.4 (reworked)
 
   // empty path shortcut

--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -6128,8 +6128,10 @@ function _prependBase(base, iri) {
     }
   }
 
+  if(rel.path !== '') {
   // remove slashes and dots in path
-  transform.path = _removeDotSegments(transform.path, !!transform.authority);
+    transform.path = _removeDotSegments(transform.path, !!transform.authority);
+  }
 
   // construct URL
   var rval = transform.protocol;

--- a/tests/test.js
+++ b/tests/test.js
@@ -159,9 +159,7 @@ var TEST_TYPES = {
     compare: compareExpectedNQuads
   },
   'jld:ToRDFTest': {
-    skip: {
-      regex: [/RFC3986/]
-    },
+    skip: {},
     fn: 'toRDF',
     params: [
       readTestUrl('input'),


### PR DESCRIPTION
Fix _removeDotSegments logic to pass all the json-ld.org RFC3986 tests.

Oddly this doesn't require the use of the hasAuthority parameter.  Is this just luck with the current json-ld.org test cases or is there an edge case where this would fail?

This patch requires https://github.com/json-ld/json-ld.org/pull/525 to fully pass the tests.