### PR TITLE
Fix compacting empty list mapped @type: @id

### DIFF
--- a/js/jsonld.js
+++ b/js/jsonld.js
@@ -5531,7 +5531,7 @@ function _compactIri(activeCtx, iri, value, relativeTo, reverse) {
       }
       var list = value['@list'];
       var commonLanguage = (list.length === 0) ? defaultLanguage : null;
-      var commonType = null;
+      var commonType = (list.length === 0) ? '@id' : null;
       for(var i = 0; i < list.length; ++i) {
         var item = list[i];
         var itemLanguage = '@none';

--- a/tests/test.js
+++ b/tests/test.js
@@ -96,7 +96,7 @@ var ROOT_MANIFEST_DIR = resolvePath(
 var TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t0074/],
+      regex: [/#t0073/],
       specVersion: ['json-ld-1.1']
     },
     fn: 'compact',


### PR DESCRIPTION
It sets default common type to `@id` for an empty list. Extracted from
existing algorithm where `@id` was a default type if list item was not a
value (empty is not a value).

The test case has been marked for 1.1 version of the spec, but has been
considered as an errata to 1.0 spec as well. See comment:
https://github.com/json-ld/json-ld.org/pull/510#issuecomment-312456440

This fixes #189 issue.