### PR TITLE
Don't expand non-string native values to node objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   feature added complexity and browser issues and the use case is likely
   handled by semantic versioning and using a proper dependency.
 
+## 0.5.x
+- Do not use native types to create IRIs in value expansion.
+
 ## 0.5.15 - 2017-10-16
 
 ### Changed

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -575,11 +575,11 @@ function _expandValue({activeCtx, activeProperty, value}) {
   const type = _getContextValue(activeCtx, activeProperty, '@type');
 
   // do @id expansion (automatic for @graph)
-  if(type === '@id' || (expandedProperty === '@graph' && _isString(value))) {
+  if((type === '@id' || expandedProperty === '@graph') && _isString(value)) {
     return {'@id': _expandIri(activeCtx, value, {base: true})};
   }
   // do @id expansion w/vocab
-  if(type === '@vocab') {
+  if(type === '@vocab' && _isString(value)) {
     return {'@id': _expandIri(activeCtx, value, {vocab: true, base: true})};
   }
 
@@ -590,7 +590,7 @@ function _expandValue({activeCtx, activeProperty, value}) {
 
   const rval = {};
 
-  if(type !== null) {
+  if(type !== null && _isString(value)) {
     // other type
     rval['@type'] = type;
   } else if(_isString(value)) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -419,8 +419,7 @@ api.expand = ({
     // add value for property
     // use an array except for certain keywords
     const useArray =
-      ['@index', '@id', '@type', '@value', '@language'].indexOf(
-        expandedProperty) === -1;
+      !['@index', '@id', '@type', '@value', '@language'].includes(expandedProperty);
     _addValue(
       rval, expandedProperty, expandedValue, {propertyIsArray: useArray});
   }
@@ -590,7 +589,7 @@ function _expandValue({activeCtx, activeProperty, value}) {
 
   const rval = {};
 
-  if(type && ['@id', '@vocab'].indexOf(type) === -1) {
+  if(type && !['@id', '@vocab'].includes(type)) {
     // other type
     rval['@type'] = type;
   } else if(_isString(value)) {
@@ -601,7 +600,7 @@ function _expandValue({activeCtx, activeProperty, value}) {
     }
   }
   // do conversion of values that aren't basic JSON types to strings
-  if(['boolean', 'number', 'string'].indexOf(typeof value) === -1) {
+  if(!['boolean', 'number', 'string'].includes(typeof value)) {
     value = value.toString();
   }
   rval['@value'] = value;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -590,7 +590,7 @@ function _expandValue({activeCtx, activeProperty, value}) {
 
   const rval = {};
 
-  if(type !== null && _isString(value)) {
+  if(type && ['@id', '@vocab'].indexOf(type) === -1) {
     // other type
     rval['@type'] = type;
   } else if(_isString(value)) {

--- a/lib/fromRdf.js
+++ b/lib/fromRdf.js
@@ -316,8 +316,7 @@ function _RDFToObject(o, useNativeTypes) {
         }
       }
       // do not add native type
-      if([XSD_BOOLEAN, XSD_INTEGER, XSD_DOUBLE, XSD_STRING]
-        .indexOf(type) === -1) {
+      if(![XSD_BOOLEAN, XSD_INTEGER, XSD_DOUBLE, XSD_STRING].includes(type)) {
         rval['@type'] = type;
       }
     } else if(type !== XSD_STRING) {


### PR DESCRIPTION
 As called for in json-ld/json-ld.org#558. There is new text in 1.1 (not dependent on `"@version": 1.1`) to ensure that native types won't be coerced to IRIs. It's quite reasonable for 1.0 processors, as such coercion is nonsensical.