### PR TITLE
Handle empty and relative @base.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Do not use native types to create IRIs in value expansion.
 - Improved error detection for @container variations.
+- Handle empty and relative `@base`.
 
 ### Changed
 - Set processingMode from options or first encountered context.

--- a/lib/context.js
+++ b/lib/context.js
@@ -16,6 +16,7 @@ const {
 
 const {
   isAbsolute: _isAbsoluteIri,
+  isRelative: _isRelativeIri,
   prependBase,
   parse: parseUrl
 } = require('./url');
@@ -115,24 +116,19 @@ api.process = ({activeCtx, localCtx, options}) => {
     if('@base' in ctx) {
       let base = ctx['@base'];
 
-      // clear base
       if(base === null) {
-        base = null;
-      } else if(!_isString(base)) {
+        // no action
+      } else if(_isAbsoluteIri(base)) {
+        base = parseUrl(base);
+      } else if(_isRelativeIri(base)) {
+        base = parseUrl(prependBase(activeCtx['@base'].href, base));
+      } else {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; the value of "@base" in a ' +
-          '@context must be a string or null.',
-          'jsonld.SyntaxError', {code: 'invalid base IRI', context: ctx});
-      } else if(base !== '' && !_isAbsoluteIri(base)) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; the value of "@base" in a ' +
-          '@context must be an absolute IRI or the empty string.',
+          '@context must be an absolute IRI, a relative IRI, or null.',
           'jsonld.SyntaxError', {code: 'invalid base IRI', context: ctx});
       }
 
-      if(base !== null) {
-        base = parseUrl(base || '');
-      }
       rval['@base'] = base;
       defined['@base'] = true;
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -269,12 +269,13 @@ api.removeDotSegments = path => {
 // TODO: time better isAbsolute/isRelative checks using full regexes:
 // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html
 
-// regex to check for starting scheme and ':'
-const isAbsoluteRegex = /^[A-Za-z][A-Za-z0-9+-.]*:/
+// regex to check for absolute IRI (starting scheme and ':') or blank node IRI
+const isAbsoluteRegex = /^([A-Za-z][A-Za-z0-9+-.]*|_):/;
 
 /**
- * Returns true if the given value is an absolute IRI, false if not.
- * Note: this is a weak check.
+ * Returns true if the given value is an absolute IRI or blank node IRI, false
+ * if not.
+ * Note: This weak check only checks for a correct starting scheme.
  *
  * @param v the value to check.
  *

--- a/lib/url.js
+++ b/lib/url.js
@@ -269,6 +269,9 @@ api.removeDotSegments = path => {
 // TODO: time better isAbsolute/isRelative checks using full regexes:
 // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html
 
+// regex to check for starting scheme and ':'
+const isAbsoluteRegex = /^[A-Za-z][A-Za-z0-9+-.]*:/
+
 /**
  * Returns true if the given value is an absolute IRI, false if not.
  * Note: this is a weak check.
@@ -277,7 +280,7 @@ api.removeDotSegments = path => {
  *
  * @return true if the value is an absolute IRI, false if not.
  */
-api.isAbsolute = v => types.isString(v) && v.includes(':');
+api.isAbsolute = v => types.isString(v) && isAbsoluteRegex.test(v);
 
 /**
  * Returns true if the given value is a relative IRI, false if not.

--- a/lib/url.js
+++ b/lib/url.js
@@ -266,11 +266,25 @@ api.removeDotSegments = path => {
   return output.join('/');
 };
 
+// TODO: time better isAbsolute/isRelative checks using full regexes:
+// http://jmrware.com/articles/2009/uri_regexp/URI_regex.html
+
 /**
  * Returns true if the given value is an absolute IRI, false if not.
+ * Note: this is a weak check.
  *
  * @param v the value to check.
  *
  * @return true if the value is an absolute IRI, false if not.
  */
-api.isAbsolute = v => types.isString(v) && v.indexOf(':') !== -1;
+api.isAbsolute = v => types.isString(v) && v.includes(':');
+
+/**
+ * Returns true if the given value is a relative IRI, false if not.
+ * Note: this is a weak check.
+ *
+ * @param v the value to check.
+ *
+ * @return true if the value is a relative IRI, false if not.
+ */
+api.isRelative = v => types.isString(v);

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -186,3 +186,18 @@ describe('loading multiple levels of contexts', () => {
     });
   });
 });
+
+describe('url tests', () => {
+  it('should detect absolute IRIs', done => {
+    assert(jsonld.url.isAbsolute('a:'));
+    assert(jsonld.url.isAbsolute('a:b'));
+    assert(jsonld.url.isAbsolute('a:b:c'));
+
+    assert(!jsonld.url.isAbsolute(':'));
+    assert(!jsonld.url.isAbsolute('a'));
+    assert(!jsonld.url.isAbsolute('/:'));
+    assert(!jsonld.url.isAbsolute('/a:'));
+    assert(!jsonld.url.isAbsolute('/a:b'));
+    done();
+  });
+});

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -189,15 +189,22 @@ describe('loading multiple levels of contexts', () => {
 
 describe('url tests', () => {
   it('should detect absolute IRIs', done => {
+    // absolute IRIs
     assert(jsonld.url.isAbsolute('a:'));
     assert(jsonld.url.isAbsolute('a:b'));
     assert(jsonld.url.isAbsolute('a:b:c'));
+    // blank nodes
+    assert(jsonld.url.isAbsolute('_:'));
+    assert(jsonld.url.isAbsolute('_:a'));
+    assert(jsonld.url.isAbsolute('_:a:b'));
 
+    // not absolute or blank node
     assert(!jsonld.url.isAbsolute(':'));
     assert(!jsonld.url.isAbsolute('a'));
     assert(!jsonld.url.isAbsolute('/:'));
     assert(!jsonld.url.isAbsolute('/a:'));
     assert(!jsonld.url.isAbsolute('/a:b'));
+    assert(!jsonld.url.isAbsolute('_'));
     done();
   });
 });


### PR DESCRIPTION
This handles the empty and relative `@base` tests from https://github.com/json-ld/json-ld.org/pull/567.

The absolute and relative iri detection is very weak.  Probably best to have a future pedantic mode that does slow checks on everything and just assume reasonable input for now.  I left a comment pointing to regexes.

Also seems the `parseUrl()` part isn't needed here for abs or rel iris?