### PR TITLE
Graph id type maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 ### Added
 - Expansion and Compaction using scoped contexts on property and `@type` terms.
 
+### Added
+- Index graph containers using `@id` and `@index`, with `@set` variations.
+- Index node objects using `@id` and `@type`, with `@set` variations.
+
 ## 0.5.15 - 2017-10-16
 
 ### Changed

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -330,8 +330,8 @@ api.compact = ({
 
         // Graph object compaction cases
         if(isGraph) {
-          if(container.includes('@graph') && container.includes('@id')) {
-            // container includes @graph and @id
+          if(container.includes('@graph') &&
+            (container.includes('@id') || container.includes('@index') && _isSimpleGraph(expandedItem))) {
             // get or create the map object
             let mapObject;
             if(itemActiveProperty in rval) {
@@ -339,22 +339,14 @@ api.compact = ({
             } else {
               rval[itemActiveProperty] = mapObject = {};
             }
+
+            // TODO: future change will use @none in both cases.
+            const key = container.includes('@id') ?
+              (expandedItem['@id'] || issuer.getId(null)) :
+              (expandedItem['@index'] || '@none');
             // add compactedItem to map, using value of `@id` or a new blank node identifier
             _addValue(
-              mapObject, (expandedItem['@id'] || issuer.getId(null)), compactedItem,
-              {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
-          } else if(container.includes('@graph') && container.includes('@index') && _isSimpleGraph(expandedItem)) {
-            // container includes @graph and @index and item is a simple graph
-            // get or create the map object
-            let mapObject;
-            if(itemActiveProperty in rval) {
-              mapObject = rval[itemActiveProperty];
-            } else {
-              rval[itemActiveProperty] = mapObject = {};
-            }
-            // add compactedItem to map, using value of `@index` or `@none`
-            _addValue(
-              mapObject, (expandedItem['@index'] || '@none'), compactedItem,
+              mapObject, key, compactedItem,
               {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
           } else if(container.includes('@graph') && _isSimpleGraph(expandedItem)) {
             // container includes @graph but not @id or @index and value is a simple graph object
@@ -387,13 +379,14 @@ api.compact = ({
           container.includes('@id') || container.includes('@type')) {
           // handle language and index maps
           // get or create the map object
-          let mapObject, key;
+          let mapObject;
           if(itemActiveProperty in rval) {
             mapObject = rval[itemActiveProperty];
           } else {
             rval[itemActiveProperty] = mapObject = {};
           }
 
+          let key;
           if(container.includes('@language')) {
           // if container is a language map, simplify compacted value to
           // a simple string
@@ -409,19 +402,25 @@ api.compact = ({
             delete compactedItem[idKey];
           } else if(container.includes('@type')) {
             const typeKey = api.compactIri({activeCtx, iri: '@type', vocab: true});
-            var types;
+            let types;
             [key, ...types] = [].concat(compactedItem[typeKey] || ['@none']);
             switch(types.length) {
-            case 0: delete compactedItem[typeKey]; break;
-            case 1: compactedItem[typeKey] = types[0]; break;
-            default: compactedItem[typeKey] = types; break;
+            case 0:
+              delete compactedItem[typeKey];
+              break;
+            case 1:
+              compactedItem[typeKey] = types[0];
+              break;
+            default:
+              compactedItem[typeKey] = types;
+              break;
             }
           }
 
           // add compact value to map object using key from expanded value
           // based on the container type
-          _addValue(mapObject, key, compactedItem,
-            {propertyIsArray: container.includes('@set')});
+          _addValue(
+            mapObject, key, compactedItem, {propertyIsArray: container.includes('@set')});
         } else {
           // use an array if: compactArrays flag is false,
           // @container is @set or @list , value is an empty

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -383,26 +383,45 @@ api.compact = ({
               rval, itemActiveProperty, compactedItem,
               {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
           }
-        } else if(container.includes('@language') || container.includes('@index')) {
-        // handle language and index maps
+        } else if(container.includes('@language') || container.includes('@index') ||
+          container.includes('@id') || container.includes('@type')) {
+          // handle language and index maps
           // get or create the map object
-          let mapObject;
+          let mapObject, key;
           if(itemActiveProperty in rval) {
             mapObject = rval[itemActiveProperty];
           } else {
             rval[itemActiveProperty] = mapObject = {};
           }
 
+          if(container.includes('@language')) {
           // if container is a language map, simplify compacted value to
           // a simple string
-          if(container.includes('@language') && _isValue(compactedItem)) {
-            compactedItem = compactedItem['@value'];
+            if(_isValue(compactedItem)) {
+              compactedItem = compactedItem['@value'];
+            }
+            key = expandedItem['@language'];
+          } else if(container.includes('@index')) {
+            key = expandedItem['@index'];
+          } else if(container.includes('@id')) {
+            const idKey = api.compactIri({activeCtx, iri: '@id', vocab: true});
+            key = compactedItem[idKey] || '@none';
+            delete compactedItem[idKey];
+          } else if(container.includes('@type')) {
+            const typeKey = api.compactIri({activeCtx, iri: '@type', vocab: true});
+            var types;
+            [key, ...types] = [].concat(compactedItem[typeKey] || ['@none']);
+            switch(types.length) {
+            case 0: delete compactedItem[typeKey]; break;
+            case 1: compactedItem[typeKey] = types[0]; break;
+            default: compactedItem[typeKey] = types; break;
+            }
           }
 
           // add compact value to map object using key from expanded value
           // based on the container type
-          const c = container.includes('@language') ? '@language' : '@index';
-          _addValue(mapObject, expandedItem[c], compactedItem);
+          _addValue(mapObject, key, compactedItem,
+            {propertyIsArray: container.includes('@set')});
         } else {
           // use an array if: compactArrays flag is false,
           // @container is @set or @list , value is an empty
@@ -480,6 +499,11 @@ api.compactIri = ({
       containers.push('@graph@id');
       containers.push('@graph@set');
       containers.push('@graph');
+    } else if(_isObject(value) && !_isValue(value)) {
+      containers.push('@id@set');
+      containers.push('@id');
+      containers.push('@type@set');
+      containers.push('@type');
     }
 
     // defaults for term selection based on type/language

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -14,6 +14,7 @@ const {
 const {
   isList: _isList,
   isValue: _isValue,
+  isGraph: _isGraph,
   isSimpleGraph: _isSimpleGraph,
   isSubjectReference: _isSubjectReference
 } = require('./graphTypes');
@@ -428,7 +429,7 @@ api.compactIri = ({
 
     // prefer `['@graph', '@set']` and then `@graph` if value is a simple graph
     // TODO: support `@graphId`?
-    if(_isSimpleGraph(value)) {
+    if(_isGraph(value)) {
       containers.push('@graph@set');
       containers.push('@graph');
     }

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -486,23 +486,32 @@ api.compactIri = ({
 
     // prefer @index if available in value
     const containers = [];
-    if(_isObject(value) && '@index' in value) {
-      containers.push('@index');
+    if(_isObject(value) && '@index' in value && !('@graph' in value)) {
+      containers.push('@index', '@index@set');
     }
 
     // prefer most specific container including @graph, prefering @set variations
     if(_isGraph(value)) {
-      containers.push('@graph@index@set');
-      containers.push('@graph@index');
-      containers.push('@graph@id@set');
-      containers.push('@graph@id');
-      containers.push('@graph@set');
-      containers.push('@graph');
+      // favor indexmap if the graph is indexed
+      if('@index' in value) {
+        containers.push('@graph@index', '@graph@index@set', '@index', '@index@set');
+      }
+      // favor idmap if the graph is has an @id
+      if('@id' in value) {
+        containers.push(
+          '@graph@id', '@graph@id@set');
+      }
+      containers.push('@graph', '@graph@set');
+      // allow indexmap if the graph is not indexed
+      if(!('@index' in value)) {
+        containers.push('@graph@index', '@graph@index@set', '@index', '@index@set');
+      }
+      // allow idmap if the graph does not have an @id
+      if(!('@id' in value)) {
+        containers.push('@graph@id', '@graph@id@set');
+      }
     } else if(_isObject(value) && !_isValue(value)) {
-      containers.push('@id@set');
-      containers.push('@id');
-      containers.push('@type@set');
-      containers.push('@type');
+      containers.push('@id', '@id@set', '@type','@set@type');
     }
 
     // defaults for term selection based on type/language
@@ -572,15 +581,22 @@ api.compactIri = ({
     } else {
       if(_isValue(value)) {
         if('@language' in value && !('@index' in value)) {
-          containers.push('@language');
+          containers.push('@language', '@language@set');
           typeOrLanguageValue = value['@language'];
         } else if('@type' in value) {
           typeOrLanguage = '@type';
           typeOrLanguageValue = value['@type'];
+        } else if(!('@index' in value)) {
+          // allw indexing by language even if no language present
+          containers.push('@language', '@language@set');
         }
       } else {
         typeOrLanguage = '@type';
         typeOrLanguageValue = '@id';
+      }
+      if(_isObject(value) && !('@index' in value)) {
+        // allow indexing even if no @index present
+        containers.push('@index', '@index@set');
       }
       containers.push('@set');
     }

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -46,7 +46,8 @@ module.exports = api;
  * @param activeProperty the compacted property associated with the element
  *          to compact, null for none.
  * @param element the element to compact.
- * @param options the compaction options.
+ * @param options the compaction options:
+ *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
  * @param compactionMap the compaction map to use.
  *
  * @return the compacted value.
@@ -132,6 +133,9 @@ api.compact = ({
     const insideReverse = (activeProperty === '@reverse');
 
     const rval = {};
+
+    // produce a map of all subjects and name each bnode
+    const issuer = options.issuer || new util.IdentifierIssuer('_:b');
 
     if(options.link && '@id' in element) {
       // store linked element
@@ -277,12 +281,12 @@ api.compact = ({
           activeCtx, itemActiveProperty, '@container') || [];
 
         // get simple @graph or @list value if appropriate
-        const isSimpleGraph = _isSimpleGraph(expandedItem);
+        const isGraph = _isGraph(expandedItem);
         const isList = _isList(expandedItem);
         let inner;
         if(isList) {
           inner = expandedItem['@list'];
-        } else if(isSimpleGraph) {
+        } else if(isGraph) {
           inner = expandedItem['@graph'];
         }
 
@@ -290,7 +294,7 @@ api.compact = ({
         let compactedItem = api.compact({
           activeCtx,
           activeProperty: itemActiveProperty,
-          element: (isList || isSimpleGraph) ? inner : expandedItem,
+          element: (isList || isGraph) ? inner : expandedItem,
           options,
           compactionMap
         });
@@ -324,22 +328,63 @@ api.compact = ({
           }
         }
 
-        // handle simple @graph
-        if(isSimpleGraph && !container.includes('@graph')) {
-          // wrap using @graph alias
-          compactedItem = {
-            [api.compactIri({activeCtx, iri: '@graph'})]: compactedItem
-          };
+        // Graph object compaction cases
+        if(isGraph) {
+          if(container.includes('@graph') && container.includes('@id')) {
+            // container includes @graph and @id
+            // get or create the map object
+            let mapObject;
+            if(itemActiveProperty in rval) {
+              mapObject = rval[itemActiveProperty];
+            } else {
+              rval[itemActiveProperty] = mapObject = {};
+            }
+            // add compactedItem to map, using value of `@id` or a new blank node identifier
+            _addValue(
+              mapObject, (expandedItem['@id'] || issuer.getId(null)), compactedItem,
+              {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
+          } else if(container.includes('@graph') && container.includes('@index') && _isSimpleGraph(expandedItem)) {
+            // container includes @graph and @index and item is a simple graph
+            // get or create the map object
+            let mapObject;
+            if(itemActiveProperty in rval) {
+              mapObject = rval[itemActiveProperty];
+            } else {
+              rval[itemActiveProperty] = mapObject = {};
+            }
+            // add compactedItem to map, using value of `@index` or `@none`
+            _addValue(
+              mapObject, (expandedItem['@index'] || '@none'), compactedItem,
+              {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
+          } else if(container.includes('@graph') && _isSimpleGraph(expandedItem)) {
+            // container includes @graph but not @id or @index and value is a simple graph object
+            // add compact value
+            _addValue(
+              rval, itemActiveProperty, compactedItem,
+              {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
+          } else {
+            // wrap using @graph alias
+            compactedItem = {
+              [api.compactIri({activeCtx, iri: '@graph'})]: compactedItem
+            };
 
-          // include @index from expanded @graph, if any
-          if('@index' in expandedItem) {
-            compactedItem[api.compactIri({activeCtx, iri: '@index'})] =
-              expandedItem['@index'];
+            // include @id from expanded graph, if any
+            if('@id' in expandedItem) {
+              compactedItem[api.compactIri({activeCtx, iri: '@id'})] =
+                expandedItem['@id'];
+            }
+
+            // include @index from expanded graph, if any
+            if('@index' in expandedItem) {
+              compactedItem[api.compactIri({activeCtx, iri: '@index'})] =
+                expandedItem['@index'];
+            }
+            _addValue(
+              rval, itemActiveProperty, compactedItem,
+              {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
           }
-        }
-
+        } else if(container.includes('@language') || container.includes('@index')) {
         // handle language and index maps
-        if(container.includes('@language') || container.includes('@index')) {
           // get or create the map object
           let mapObject;
           if(itemActiveProperty in rval) {
@@ -427,9 +472,12 @@ api.compactIri = ({
       containers.push('@index');
     }
 
-    // prefer `['@graph', '@set']` and then `@graph` if value is a simple graph
-    // TODO: support `@graphId`?
+    // prefer most specific container including @graph, prefering @set variations
     if(_isGraph(value)) {
+      containers.push('@graph@index@set');
+      containers.push('@graph@index');
+      containers.push('@graph@id@set');
+      containers.push('@graph@id');
       containers.push('@graph@set');
       containers.push('@graph');
     }

--- a/lib/context.js
+++ b/lib/context.js
@@ -402,10 +402,28 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
     // JSON-LD 1.1 support
     if(activeCtx.processingMode && activeCtx.processingMode.indexOf('json-ld-1.1') === 0) {
       // TODO: @id and @type
-      validContainers.push('@graph');
+      validContainers.push('@graph', '@id');
 
       // check container length
-      isValid &= container.length <= (hasSet ? 2 : 1);
+      if(container.includes('@list')) {
+        if(container.length !== 1) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; @context @container with @list must have no other values',
+            'jsonld.SyntaxError',
+            {code: 'invalid container mapping', context: localCtx});
+        }
+      } else if(container.includes('@graph')) {
+        if(container.some(key => key != '@graph' && key != '@id' && key != '@index' && key != '@set')) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; @context @container with @graph must have no other values ' +
+            'other than @id, @index, and @set',
+            'jsonld.SyntaxError',
+            {code: 'invalid container mapping', context: localCtx});
+        }
+      } else {
+        // otherwise, container may also include @set
+        isValid &= container.length <= (hasSet ? 2 : 1);
+      }
     } else {
       // in JSON-LD 1.0, container must not be an array (it must be a string, which is one of the validContainers)
       isValid &= !_isArray(value['@container']);

--- a/lib/context.js
+++ b/lib/context.js
@@ -413,7 +413,7 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
             {code: 'invalid container mapping', context: localCtx});
         }
       } else if(container.includes('@graph')) {
-        if(container.some(key => key != '@graph' && key != '@id' && key != '@index' && key != '@set')) {
+        if(container.some(key => key !== '@graph' && key !== '@id' && key !== '@index' && key !== '@set')) {
           throw new JsonLdError(
             'Invalid JSON-LD syntax; @context @container with @graph must have no other values ' +
             'other than @id, @index, and @set',

--- a/lib/context.js
+++ b/lib/context.js
@@ -402,7 +402,7 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
     // JSON-LD 1.1 support
     if(activeCtx.processingMode && activeCtx.processingMode.indexOf('json-ld-1.1') === 0) {
       // TODO: @id and @type
-      validContainers.push('@graph', '@id');
+      validContainers.push('@graph', '@id', '@type');
 
       // check container length
       if(container.includes('@list')) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -704,7 +704,13 @@ function _expandIndexMap(
   const rval = [];
   const keys = Object.keys(value).sort();
   for(let ki = 0; ki < keys.length; ++ki) {
-    // If indexKey is @id or @type, expand the key appropriately
+    // if indexKey is @type, there may be a context defined for it
+    const ctx = _getContextValue(activeCtx, keys[ki], '@context');
+    if(ctx) {
+      activeCtx = _processContext({activeCtx, localCtx: ctx, options});
+    }
+
+    // if indexKey is @id or @type, expand the key appropriately
     const key = (indexKey === '@id' || indexKey === '@type') ?
       _expandIri(activeCtx, keys[ki], {vocab: (indexKey === '@type'), base: true}) :
       keys[ki];

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -13,7 +13,9 @@ const {
 
 const {
   isList: _isList,
-  isValue: _isValue
+  isValue: _isValue,
+  isGraph: _isGraph,
+  isSimpleGraph: _isSimpleGraph
 } = require('./graphTypes');
 
 const {
@@ -412,7 +414,8 @@ api.expand = ({
     }
 
     // convert expanded value to @graph if container specifies it
-    if(container.includes('@graph')) {
+    // and value is not, itself, a graph
+    if(container.includes('@graph') && !_isGraph(expandedValue)) {
       // ensure expanded value is an array
       expandedValue = [].concat(expandedValue);
       expandedValue = {'@graph': expandedValue};

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -366,6 +366,17 @@ api.expand = ({
         asGraph,
         indexKey: '@id'
       });
+    } else if(container.includes('@type') && _isObject(value)) {
+      // handle type container (skip if value is not an object)
+      expandedValue = _expandIndexMap({
+        activeCtx,
+        options,
+        activeProperty: key,
+        value,
+        expansionMap,
+        asGraph: false,
+        indexKey: '@type'
+      });
     } else {
       // recurse into @list or @set
       const isList = (expandedProperty === '@list');
@@ -693,8 +704,11 @@ function _expandIndexMap(
   const rval = [];
   const keys = Object.keys(value).sort();
   for(let ki = 0; ki < keys.length; ++ki) {
-    const key = keys[ki];
-    let val = value[key];
+    // If indexKey is @id or @type, expand the key appropriately
+    const key = (indexKey === '@id' || indexKey === '@type') ?
+      _expandIri(activeCtx, keys[ki], {vocab: (indexKey === '@type'), base: true}) :
+      keys[ki];
+    let val = value[keys[ki]];
     if(!_isArray(val)) {
       val = [val];
     }
@@ -713,7 +727,13 @@ function _expandIndexMap(
       if(asGraph && !_isGraph(item)) {
         item = {'@graph': [item]};
       }
-      if(!(indexKey in item)) {
+      if(indexKey === '@type') {
+        if(item['@type']) {
+          item['@type'] = [key].concat(item['@type']);
+        } else {
+          item['@type'] = [key];
+        }
+      } else if(!(indexKey in item)) {
         item[indexKey] = key;
       }
       rval.push(item);

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -344,12 +344,14 @@ api.expand = ({
       expandedValue = _expandLanguageMap(value);
     } else if(container.includes('@index') && _isObject(value)) {
       // handle index container (skip if value is not an object)
+      const asGraph = container.includes('@graph');
       expandedValue = _expandIndexMap({
         activeCtx: termCtx,
         options,
         activeProperty: key,
         value,
-        expansionMap
+        expansionMap,
+        asGraph
       });
     } else {
       // recurse into @list or @set
@@ -415,7 +417,10 @@ api.expand = ({
 
     // convert expanded value to @graph if container specifies it
     // and value is not, itself, a graph
-    if(container.includes('@graph') && !_isGraph(expandedValue)) {
+    // index cases handled above
+    if(container.includes('@graph') &&
+      !container.some(key => key == '@id' || key == '@index') &&
+      !_isGraph(expandedValue)) {
       // ensure expanded value is an array
       expandedValue = [].concat(expandedValue);
       expandedValue = {'@graph': expandedValue};
@@ -671,7 +676,7 @@ function _expandLanguageMap(languageMap) {
 }
 
 function _expandIndexMap(
-  {activeCtx, options, activeProperty, value, expansionMap}) {
+  {activeCtx, options, activeProperty, value, expansionMap, asGraph}) {
   const rval = [];
   const keys = Object.keys(value).sort();
   for(let ki = 0; ki < keys.length; ++ki) {
@@ -689,7 +694,12 @@ function _expandIndexMap(
       expansionMap
     });
     for(let vi = 0; vi < val.length; ++vi) {
-      const item = val[vi];
+      let item = val[vi];
+
+      // If this is also a @graph container, turn items into graphs
+      if(asGraph && !_isGraph(item)) {
+        item = {'@graph': [item]};
+      }
       if(!('@index' in item)) {
         item['@index'] = key;
       }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -351,7 +351,20 @@ api.expand = ({
         activeProperty: key,
         value,
         expansionMap,
-        asGraph
+        asGraph,
+        indexKey: '@index'
+      });
+    } else if(container.includes('@id') && _isObject(value)) {
+      // handle id container (skip if value is not an object)
+      const asGraph = container.includes('@graph');
+      expandedValue = _expandIndexMap({
+        activeCtx,
+        options,
+        activeProperty: key,
+        value,
+        expansionMap,
+        asGraph,
+        indexKey: '@id'
       });
     } else {
       // recurse into @list or @set
@@ -676,7 +689,7 @@ function _expandLanguageMap(languageMap) {
 }
 
 function _expandIndexMap(
-  {activeCtx, options, activeProperty, value, expansionMap, asGraph}) {
+  {activeCtx, options, activeProperty, value, expansionMap, asGraph, indexKey}) {
   const rval = [];
   const keys = Object.keys(value).sort();
   for(let ki = 0; ki < keys.length; ++ki) {
@@ -700,8 +713,8 @@ function _expandIndexMap(
       if(asGraph && !_isGraph(item)) {
         item = {'@graph': [item]};
       }
-      if(!('@index' in item)) {
-        item['@index'] = key;
+      if(!(indexKey in item)) {
+        item[indexKey] = key;
       }
       rval.push(item);
     }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -443,7 +443,7 @@ api.expand = ({
     // and value is not, itself, a graph
     // index cases handled above
     if(container.includes('@graph') &&
-      !container.some(key => key == '@id' || key == '@index') &&
+      !container.some(key => key === '@id' || key === '@index') &&
       !_isGraph(expandedValue)) {
       // ensure expanded value is an array
       expandedValue = [].concat(expandedValue);

--- a/lib/graphTypes.js
+++ b/lib/graphTypes.js
@@ -79,7 +79,7 @@ api.isGraph = v => {
   // 3. It may have '@id' or '@index'
   return types.isObject(v) &&
     '@graph' in v &&
-    Object.keys(v).filter(key => key != '@id' && key != '@index').length === 1;
+    Object.keys(v).filter(key => key !== '@id' && key !== '@index').length === 1;
 };
 
 /**

--- a/lib/graphTypes.js
+++ b/lib/graphTypes.js
@@ -68,6 +68,21 @@ api.isList = v =>
   types.isObject(v) && ('@list' in v);
 
 /**
+ * Returns true if the given value is a @graph.
+ *
+ * @return true if the value is a @graph, false if not.
+ */
+api.isGraph = v => {
+  // Note: A value is a graph if all of these hold true:
+  // 1. It is an object.
+  // 2. It has an `@graph` key.
+  // 3. It may have '@id' or '@index'
+  return types.isObject(v) &&
+    '@graph' in v &&
+    Object.keys(v).filter(key => key != '@id' && key != '@index').length === 1;
+};
+
+/**
  * Returns true if the given value is a simple @graph.
  *
  * @return true if the value is a simple @graph, false if not.
@@ -77,12 +92,7 @@ api.isSimpleGraph = v => {
   // 1. It is an object.
   // 2. It has an `@graph` key.
   // 3. It has only 1 key or 2 keys where one of them is `@index`.
-  if(!types.isObject(v)) {
-    return false;
-  }
-  const keyLength = Object.keys(v).length;
-  return ('@graph' in v &&
-    (keyLength === 1 || (keyLength === 2 && '@index' in v)));
+  return api.isGraph(v) && !('@id' in v);
 };
 
 /**

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -136,7 +136,8 @@ jsonld.compact = util.callbackify(async function(input, ctx, options) {
     compactArrays: true,
     graph: false,
     skipExpansion: false,
-    link: false
+    link: false,
+    issuer: new IdentifierIssuer('_:b')
   });
   if(options.link) {
     // force skip expansion when linking, "link" is not part of the public

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -41,7 +41,7 @@ const TEST_TYPES = {
   },
   'jld:ExpandTest': {
     skip: {
-      regex: [/#t[n]/, /#t008[8-7]/]
+      regex: [/#t[n]/]
     },
     fn: 'expand',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -41,7 +41,7 @@ const TEST_TYPES = {
   },
   'jld:ExpandTest': {
     skip: {
-      regex: [/#t[n]/, /#tm013/]
+      regex: [/#tn/]
     },
     fn: 'expand',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,7 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t[anps]/
+      regex: [/#t0073/, /#t[anps]/]
     },
     fn: 'compact',
     params: [
@@ -41,7 +41,7 @@ const TEST_TYPES = {
   },
   'jld:ExpandTest': {
     skip: {
-      regex: [/#t[n]/]
+      regex: [/#t[n]/, /#tm013/]
     },
     fn: 'expand',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,7 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t[anps]/, /#t008[0-8]/, /#tm00[0-6]/, /#tm012/]
+      regex: [/#t0073/, /#t[anps]/, /#t008[1-8]/, /#tm00[0-6]/, /#tm012/]
     },
     fn: 'compact',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,7 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t[amnps]/], /#t008[1-8]/, /#tm00[0-6]/, /#tm012/]
+      regex: [/#t0073/, /#t[anps]/
     },
     fn: 'compact',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,7 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t[anps]/]
+      regex: [/#t0073/, /#t[anp]/]
     },
     fn: 'compact',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,7 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t[anps]/, /#t008[1-8]/, /#tm00[0-6]/, /#tm012/]
+      regex: [/#t0073/, /#t[amnps]/], /#t008[1-8]/, /#tm00[0-6]/, /#tm012/]
     },
     fn: 'compact',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -41,7 +41,7 @@ const TEST_TYPES = {
   },
   'jld:ExpandTest': {
     skip: {
-      regex: [/#tn/, /#t008[0-7]/, /#tm00[0-7]/, /#tm013/]
+      regex: [/#t[n]/, /#t008[8-7]/]
     },
     fn: 'expand',
     params: [


### PR DESCRIPTION
This adds support for graph indexing on `@id` and `@index`, as well as id maps and type maps.

It is based on the `processingMode` branch, but is targeted for 0.6.x. The 0.6.x branch will require rebasing from 0.5.x until that branch is completed.