### PR TITLE
Check for keys in term definition outside that expected

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -279,12 +279,6 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
         'contain @id.', 'jsonld.SyntaxError',
         {code: 'invalid reverse property', context: localCtx});
     }
-    if('@nest' in value) {
-      throw new JsonLdError(
-        'Invalid JSON-LD syntax; a @reverse term definition must not ' +
-        'contain @nest.', 'jsonld.SyntaxError',
-        {code: 'invalid reverse property', context: localCtx});
-    }
     const reverse = value['@reverse'];
     if(!_isString(reverse)) {
       throw new JsonLdError(
@@ -458,10 +452,6 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
       language = language.toLowerCase();
     }
     mapping['@language'] = language;
-  }
-
-  if('@next' in value) {
-    
   }
 
   // disallow aliasing @context and @preserve
@@ -829,7 +819,6 @@ api.isKeyword = v => {
   case '@index':
   case '@language':
   case '@list':
-  case '@nest':
   case '@omitDefault':
   case '@preserve':
   case '@requireAll':

--- a/lib/context.js
+++ b/lib/context.js
@@ -260,11 +260,29 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
   const mapping = activeCtx.mappings[term] = {};
   mapping.reverse = false;
 
+  // make sure term definition only has expected keywords
+  const validKeys = ['@container', '@id', '@language', '@reverse', '@type'];
+
+  for(let kw in value) {
+    if(!validKeys.includes(kw)) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; a term definition must not contain ' + kw,
+        'jsonld.SyntaxError',
+        {code: 'invalid term definition', context: localCtx});
+    }
+  }
+
   if('@reverse' in value) {
     if('@id' in value) {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; a @reverse term definition must not ' +
         'contain @id.', 'jsonld.SyntaxError',
+        {code: 'invalid reverse property', context: localCtx});
+    }
+    if('@nest' in value) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; a @reverse term definition must not ' +
+        'contain @nest.', 'jsonld.SyntaxError',
         {code: 'invalid reverse property', context: localCtx});
     }
     const reverse = value['@reverse'];
@@ -440,6 +458,10 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
       language = language.toLowerCase();
     }
     mapping['@language'] = language;
+  }
+
+  if('@next' in value) {
+    
   }
 
   // disallow aliasing @context and @preserve
@@ -807,6 +829,7 @@ api.isKeyword = v => {
   case '@index':
   case '@language':
   case '@list':
+  case '@nest':
   case '@omitDefault':
   case '@preserve':
   case '@requireAll':


### PR DESCRIPTION
`@container`, `@id`, `@language`, `@reverse`, and `@type`. This also sets up for additional keywords in 1.1.