### PR TITLE
Support nested property expansion and compaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@
 
 ### Added
 - Expansion and Compaction using scoped contexts on property and `@type` terms.
-
-### Added
+- Expansion and Compaction of nested properties.
 - Index graph containers using `@id` and `@index`, with `@set` variations.
 - Index node objects using `@id` and `@type`, with `@set` variations.
 

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -143,7 +143,7 @@ api.compact = ({
 
     // process element keys in order
     const keys = Object.keys(element).sort();
-    for(let expandedProperty of keys) {
+    for(const expandedProperty of keys) {
       const expandedValue = element[expandedProperty];
 
       // compact @id and @type(s)
@@ -160,7 +160,7 @@ api.compact = ({
         } else {
           // expanded value must be a @type array
           compactedValue = [];
-          for(let expandedIri of expandedValue) {
+          for(const expandedIri of expandedValue) {
             const compactedType = api.compactIri(
               {activeCtx, iri: expandedIri, relativeTo: {vocab: true}})
 
@@ -193,7 +193,7 @@ api.compact = ({
         });
 
         // handle double-reversed properties
-        for(let compactedProperty in compactedValue) {
+        for(const compactedProperty in compactedValue) {
           if(activeCtx.mappings[compactedProperty] &&
             activeCtx.mappings[compactedProperty].reverse) {
             const value = compactedValue[compactedProperty];
@@ -270,7 +270,7 @@ api.compact = ({
       }
 
       // recusively process array values
-      for(let expandedItem of expandedValue) {
+      for(const expandedItem of expandedValue) {
         // compact property and get container type
         const itemActiveProperty = api.compactIri({
           activeCtx,
@@ -844,7 +844,7 @@ api.removePreserve = (ctx, input, options) => {
     }
 
     // recurse through properties
-    for(let prop in input) {
+    for(const prop in input) {
       let result = api.removePreserve(ctx, input[prop], options);
       const container = _getContextValue(ctx, prop, '@container') || [];
       if(options.compactArrays && _isArray(result) && result.length === 1 &&

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -143,8 +143,7 @@ api.compact = ({
 
     // process element keys in order
     const keys = Object.keys(element).sort();
-    for(let ki = 0; ki < keys.length; ++ki) {
-      const expandedProperty = keys[ki];
+    for(let expandedProperty of keys) {
       const expandedValue = element[expandedProperty];
 
       // compact @id and @type(s)
@@ -161,9 +160,9 @@ api.compact = ({
         } else {
           // expanded value must be a @type array
           compactedValue = [];
-          for(let vi = 0; vi < expandedValue.length; ++vi) {
+          for(let expandedIri of expandedValue) {
             const compactedType = api.compactIri(
-              {activeCtx, iri: expandedValue[vi], relativeTo: {vocab: true}})
+              {activeCtx, iri: expandedIri, relativeTo: {vocab: true}})
 
             // Use any scoped context defined on this value
             const ctx = _getContextValue(activeCtx, compactedType, '@context');
@@ -257,14 +256,21 @@ api.compact = ({
           relativeTo: {vocab: true},
           reverse: insideReverse
         });
+        const nestProperty = (itemActiveProperty in activeCtx.mappings) ? activeCtx.mappings[itemActiveProperty]['@nest'] : null;
+        let nestResult = rval;
+        if(nestProperty) {
+          _checkNestProperty(activeCtx, nestProperty);
+          if(!_isObject(rval[nestProperty])) {
+            rval[nestProperty] = {};
+          }
+          nestResult = rval[nestProperty];
+        }
         _addValue(
-          rval, itemActiveProperty, expandedValue, {propertyIsArray: true});
+          nestResult, itemActiveProperty, expandedValue, {propertyIsArray: true});
       }
 
       // recusively process array values
-      for(let vi = 0; vi < expandedValue.length; ++vi) {
-        const expandedItem = expandedValue[vi];
-
+      for(let expandedItem of expandedValue) {
         // compact property and get container type
         const itemActiveProperty = api.compactIri({
           activeCtx,
@@ -273,6 +279,18 @@ api.compact = ({
           relativeTo: {vocab: true},
           reverse: insideReverse
         });
+
+        // if itemActiveProperty is a @nest property, add values to nestResult, otherwise rval
+        const nestProperty = (itemActiveProperty in activeCtx.mappings) ? activeCtx.mappings[itemActiveProperty]['@nest'] : null;
+        let nestResult = rval;
+        if(nestProperty) {
+          _checkNestProperty(activeCtx, nestProperty);
+          if(!_isObject(rval[nestProperty])) {
+            rval[nestProperty] = {};
+          }
+          nestResult = rval[nestProperty];
+        }
+
         const container = _getContextValue(
           activeCtx, itemActiveProperty, '@container') || [];
 
@@ -313,7 +331,7 @@ api.compact = ({
               compactedItem[api.compactIri({activeCtx, iri: '@index', relativeTo: {vocab: true}})] =
                 expandedItem['@index'];
             }
-          } else if(itemActiveProperty in rval) {
+          } else if(itemActiveProperty in nestResult) {
             // can't use @list container for more than 1 list
             throw new JsonLdError(
               'JSON-LD compact error; property has a "@list" @container ' +
@@ -330,10 +348,10 @@ api.compact = ({
             (container.includes('@id') || container.includes('@index') && _isSimpleGraph(expandedItem))) {
             // get or create the map object
             let mapObject;
-            if(itemActiveProperty in rval) {
-              mapObject = rval[itemActiveProperty];
+            if(itemActiveProperty in nestResult) {
+              mapObject = nestResult[itemActiveProperty];
             } else {
-              rval[itemActiveProperty] = mapObject = {};
+              nestResult[itemActiveProperty] = mapObject = {};
             }
 
             // index on @id or @index or alias of @none
@@ -347,7 +365,7 @@ api.compact = ({
             // container includes @graph but not @id or @index and value is a simple graph object
             // add compact value
             _addValue(
-              rval, itemActiveProperty, compactedItem,
+              nestResult, itemActiveProperty, compactedItem,
               {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
           } else {
             // wrap using @graph alias
@@ -367,7 +385,7 @@ api.compact = ({
                 expandedItem['@index'];
             }
             _addValue(
-              rval, itemActiveProperty, compactedItem,
+              nestResult, itemActiveProperty, compactedItem,
               {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
           }
         } else if(container.includes('@language') || container.includes('@index') ||
@@ -375,10 +393,10 @@ api.compact = ({
           // handle language and index maps
           // get or create the map object
           let mapObject;
-          if(itemActiveProperty in rval) {
-            mapObject = rval[itemActiveProperty];
+          if(itemActiveProperty in nestResult) {
+            mapObject = nestResult[itemActiveProperty];
           } else {
-            rval[itemActiveProperty] = mapObject = {};
+            nestResult[itemActiveProperty] = mapObject = {};
           }
 
           let key;
@@ -431,7 +449,7 @@ api.compact = ({
 
           // add compact value
           _addValue(
-            rval, itemActiveProperty, compactedItem,
+            nestResult, itemActiveProperty, compactedItem,
             {propertyIsArray: isArray});
         }
       }
@@ -906,4 +924,19 @@ function _selectTerm(
   }
 
   return null;
+}
+
+/**
+ * The value of `@nest` in the term definition must either be `@nest`, or a term
+ * which resolves to `@nest`.
+ *
+ * @param activeCtx the active context.
+ * @param nestProperty a term in the active context or `@nest`.
+ */
+function _checkNestProperty(activeCtx, nestProperty) {
+  if(_expandIri(activeCtx, nestProperty, {vocab: true}) !== '@nest') {
+    throw new JsonLdError(
+      'JSON-LD compact error; nested property must have an @nest value resolving to @nest.',
+      'jsonld.SyntaxError', {code: 'invalid @nest value'});
+  }
 }

--- a/lib/context.js
+++ b/lib/context.js
@@ -172,7 +172,7 @@ api.process = ({activeCtx, localCtx, options}) => {
     }
 
     // process all other keys
-    for(let key in ctx) {
+    for(const key in ctx) {
       api.createTermDefinition(rval, ctx, key, defined);
     }
 
@@ -266,7 +266,7 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
     validKeys.push('@context', '@nest', '@prefix');
   }
 
-  for(let kw in value) {
+  for(const kw in value) {
     if(!validKeys.includes(kw)) {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; a term definition must not contain ' + kw,
@@ -730,7 +730,7 @@ api.getInitialContext = (options) => {
     }
 
     // build fast CURIE map
-    for(let key in fastCurieMap) {
+    for(const key in fastCurieMap) {
       _buildIriMap(fastCurieMap, key, 1);
     }
 
@@ -765,7 +765,7 @@ api.getInitialContext = (options) => {
       }
     }
 
-    for(let key in next) {
+    for(const key in next) {
       if(key === '') {
         continue;
       }
@@ -1042,7 +1042,7 @@ function _findContextUrls(input, urls, replace, base) {
   }
 
   // input is an object
-  for(let key in input) {
+  for(const key in input) {
     if(key !== '@context') {
       _findContextUrls(input[key], urls, replace, base);
       continue;
@@ -1077,7 +1077,7 @@ function _findContextUrls(input, urls, replace, base) {
           }
         } else {
           // look for scoped context
-          for(let key in _ctx) {
+          for(const key in _ctx) {
             if(_isObject(_ctx[key])) {
               _findContextUrls(_ctx[key], urls, replace, base);
             }
@@ -1098,7 +1098,7 @@ function _findContextUrls(input, urls, replace, base) {
       }
     } else {
       // look for scoped context
-      for(let key in ctx) {
+      for(const key in ctx) {
         if(_isObject(ctx[key])) {
           _findContextUrls(ctx[key], urls, replace, base);
         }

--- a/lib/context.js
+++ b/lib/context.js
@@ -263,7 +263,7 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
 
   // JSON-LD 1.1 support
   if(api.processingMode(activeCtx, 1.1)) {
-    validKeys.push('@context', '@prefix');
+    validKeys.push('@context', '@nest', '@prefix');
   }
 
   for(let kw in value) {
@@ -285,6 +285,12 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; a @reverse term definition must not ' +
         'contain @id.', 'jsonld.SyntaxError',
+        {code: 'invalid reverse property', context: localCtx});
+    }
+    if('@nest' in value) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; a @reverse term definition must not ' +
+        'contain @nest.', 'jsonld.SyntaxError',
         {code: 'invalid reverse property', context: localCtx});
     }
     const reverse = value['@reverse'];
@@ -500,6 +506,17 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
         'jsonld.SyntaxError',
         {code: 'invalid @prefix value', context: localCtx});
     }
+  }
+
+  if('@nest' in value) {
+    let nest = value['@nest'];
+    if(!_isString(nest) || (nest !== '@nest' && nest.indexOf('@') === 0)) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; @context @nest value must be ' +
+        'a string which is not a keyword other than @nest.', 'jsonld.SyntaxError',
+        {code: 'invalid @nest value', context: localCtx});
+    }
+    mapping['@nest'] = nest;
   }
 
   // disallow aliasing @context and @preserve
@@ -883,6 +900,7 @@ api.isKeyword = v => {
   case '@index':
   case '@language':
   case '@list':
+  case '@nest':
   case '@none':
   case '@omitDefault':
   case '@prefix':

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -161,7 +161,6 @@ api.expand = ({
     }
   }
 
-
   // expand the active property
   const expandedActiveProperty = _expandIri(
     activeCtx, activeProperty, {vocab: true});
@@ -455,7 +454,7 @@ function _expandObject({
       });
       // properties double-reversed
       if('@reverse' in expandedValue) {
-        for(let property in expandedValue['@reverse']) {
+        for(const property in expandedValue['@reverse']) {
           _addValue(
             expandedParent, property, expandedValue['@reverse'][property],
             {propertyIsArray: true});
@@ -465,7 +464,7 @@ function _expandObject({
       // FIXME: can this be merged with code below to simplify?
       // merge in all reversed properties
       let reverseMap = expandedParent['@reverse'] || null;
-      for(let property in expandedValue) {
+      for(const property in expandedValue) {
         if(property === '@reverse') {
           continue;
         }
@@ -644,9 +643,9 @@ function _expandObject({
   }
 
   // expand each nested key
-  for(let key of nests) {
+  for(const key of nests) {
     const nestedValues = _isArray(element[key]) ? element[key] : [element[key]];
-    for(let nv of nestedValues) {
+    for(const nv of nestedValues) {
       if(!_isObject(nv) ||
         Object.keys(nv).some(k => _expandIri(activeCtx, k, {vocab: true}) === '@value')) {
           throw new JsonLdError(
@@ -740,13 +739,13 @@ function _expandValue({activeCtx, activeProperty, value}) {
 function _expandLanguageMap(activeCtx, languageMap) {
   const rval = [];
   const keys = Object.keys(languageMap).sort();
-  for(let key of keys) {
+  for(const key of keys) {
     const expandedKey = _expandIri(activeCtx, key, {vocab: true})
     let val = languageMap[key];
     if(!_isArray(val)) {
       val = [val];
     }
-    for(let item of val) {
+    for(const item of val) {
       if(item === null) {
         // null values are allowed (8.5) but ignored (3.1)
         continue;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -145,9 +145,8 @@ api.expand = ({
       {activeCtx, localCtx: element['@context'], options});
   }
 
-  let keys = Object.keys(element).sort();
-
   // look for scoped context on @type
+  let keys = Object.keys(element).sort();
   for(const key of keys) {
     const expandedProperty = _expandIri(activeCtx, key, {vocab: true});
     if(expandedProperty === '@type') {
@@ -162,321 +161,22 @@ api.expand = ({
     }
   }
 
+
   // expand the active property
   const expandedActiveProperty = _expandIri(
     activeCtx, activeProperty, {vocab: true});
 
+  // process each key and value in element, ignoring @nest content
   let rval = {};
-  for(const key of keys) {
-    let value = element[key];
-    let expandedValue;
-
-    // skip @context
-    if(key === '@context') {
-      continue;
-    }
-
-    // expand property
-    let expandedProperty = _expandIri(activeCtx, key, {vocab: true});
-
-    // drop non-absolute IRI keys that aren't keywords unless custom mapped
-    if(expandedProperty === null ||
-      !(_isAbsoluteIri(expandedProperty) || _isKeyword(expandedProperty))) {
-      // TODO: use `await` to support async
-      expandedProperty = expansionMap({
-        unmappedProperty: key,
-        activeCtx,
-        activeProperty,
-        parent: element,
-        options,
-        insideList,
-        value,
-        expandedParent: rval
-      });
-      if(expandedProperty === undefined) {
-        continue;
-      }
-    }
-
-    if(_isKeyword(expandedProperty)) {
-      if(expandedActiveProperty === '@reverse') {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; a keyword cannot be used as a @reverse ' +
-          'property.', 'jsonld.SyntaxError',
-          {code: 'invalid reverse property map', value: value});
-      }
-      if(expandedProperty in rval) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; colliding keywords detected.',
-          'jsonld.SyntaxError',
-          {code: 'colliding keywords', keyword: expandedProperty});
-      }
-    }
-
-    // syntax error if @id is not a string
-    if(expandedProperty === '@id' && !_isString(value)) {
-      if(!options.isFrame) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; "@id" value must a string.',
-          'jsonld.SyntaxError', {code: 'invalid @id value', value: value});
-      }
-      if(!_isObject(value)) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; "@id" value must be a string or an ' +
-          'object.', 'jsonld.SyntaxError',
-          {code: 'invalid @id value', value: value});
-      }
-    }
-
-    if(expandedProperty === '@type') {
-      _validateTypeValue(value);
-    }
-
-    // @graph must be an array or an object
-    if(expandedProperty === '@graph' &&
-      !(_isObject(value) || _isArray(value))) {
-      throw new JsonLdError(
-        'Invalid JSON-LD syntax; "@graph" value must not be an ' +
-        'object or an array.',
-        'jsonld.SyntaxError', {code: 'invalid @graph value', value: value});
-    }
-
-    // @value must not be an object or an array
-    if(expandedProperty === '@value' &&
-      (_isObject(value) || _isArray(value))) {
-      throw new JsonLdError(
-        'Invalid JSON-LD syntax; "@value" value must not be an ' +
-        'object or an array.',
-        'jsonld.SyntaxError',
-        {code: 'invalid value object value', value: value});
-    }
-
-    // @language must be a string
-    if(expandedProperty === '@language') {
-      if(value === null) {
-        // drop null @language values, they expand as if they didn't exist
-        continue;
-      }
-      if(!_isString(value)) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; "@language" value must be a string.',
-          'jsonld.SyntaxError',
-          {code: 'invalid language-tagged string', value: value});
-      }
-      // ensure language value is lowercase
-      value = value.toLowerCase();
-    }
-
-    // @index must be a string
-    if(expandedProperty === '@index') {
-      if(!_isString(value)) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; "@index" value must be a string.',
-          'jsonld.SyntaxError',
-          {code: 'invalid @index value', value: value});
-      }
-    }
-
-    // @reverse must be an object
-    if(expandedProperty === '@reverse') {
-      if(!_isObject(value)) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; "@reverse" value must be an object.',
-          'jsonld.SyntaxError', {code: 'invalid @reverse value', value: value});
-      }
-
-      expandedValue = api.expand({
-        activeCtx,
-        activeProperty:
-        '@reverse',
-        element: value,
-        options,
-        expansionMap
-      });
-
-      // properties double-reversed
-      if('@reverse' in expandedValue) {
-        for(let property in expandedValue['@reverse']) {
-          _addValue(
-            rval, property, expandedValue['@reverse'][property],
-            {propertyIsArray: true});
-        }
-      }
-
-      // FIXME: can this be merged with code below to simplify?
-      // merge in all reversed properties
-      let reverseMap = rval['@reverse'] || null;
-      for(let property in expandedValue) {
-        if(property === '@reverse') {
-          continue;
-        }
-        if(reverseMap === null) {
-          reverseMap = rval['@reverse'] = {};
-        }
-        _addValue(reverseMap, property, [], {propertyIsArray: true});
-        const items = expandedValue[property];
-        for(let ii = 0; ii < items.length; ++ii) {
-          const item = items[ii];
-          if(_isValue(item) || _isList(item)) {
-            throw new JsonLdError(
-              'Invalid JSON-LD syntax; "@reverse" value must not be a ' +
-              '@value or an @list.', 'jsonld.SyntaxError',
-              {code: 'invalid reverse property value', value: expandedValue});
-          }
-          _addValue(reverseMap, property, item, {propertyIsArray: true});
-        }
-      }
-
-      continue;
-    }
-
-    // use potential scoped context for key
-    let termCtx = activeCtx;
-    const ctx = _getContextValue(activeCtx, key, '@context');
-    if(ctx) {
-      termCtx = _processContext({activeCtx, localCtx: ctx, options});
-    }
-
-    const container = _getContextValue(termCtx, key, '@container') || [];
-
-    if(container.includes('@language') && _isObject(value)) {
-      // handle language map container (skip if value is not an object)
-      expandedValue = _expandLanguageMap(termCtx, value);
-    } else if(container.includes('@index') && _isObject(value)) {
-      // handle index container (skip if value is not an object)
-      const asGraph = container.includes('@graph');
-      expandedValue = _expandIndexMap({
-        activeCtx: termCtx,
-        options,
-        activeProperty: key,
-        value,
-        expansionMap,
-        asGraph,
-        indexKey: '@index'
-      });
-    } else if(container.includes('@id') && _isObject(value)) {
-      // handle id container (skip if value is not an object)
-      const asGraph = container.includes('@graph');
-      expandedValue = _expandIndexMap({
-        activeCtx: termCtx,
-        options,
-        activeProperty: key,
-        value,
-        expansionMap,
-        asGraph,
-        indexKey: '@id'
-      });
-    } else if(container.includes('@type') && _isObject(value)) {
-      // handle type container (skip if value is not an object)
-      expandedValue = _expandIndexMap({
-        activeCtx,
-        options,
-        activeProperty: key,
-        value,
-        expansionMap,
-        asGraph: false,
-        indexKey: '@type'
-      });
-    } else {
-      // recurse into @list or @set
-      const isList = (expandedProperty === '@list');
-      if(isList || expandedProperty === '@set') {
-        let nextActiveProperty = activeProperty;
-        if(isList && expandedActiveProperty === '@graph') {
-          nextActiveProperty = null;
-        }
-        expandedValue = api.expand({
-          activeCtx: termCtx,
-          activeProperty: nextActiveProperty,
-          element: value,
-          options,
-          insideList: isList,
-          expansionMap
-        });
-        if(isList && _isList(expandedValue)) {
-          throw new JsonLdError(
-            'Invalid JSON-LD syntax; lists of lists are not permitted.',
-            'jsonld.SyntaxError', {code: 'list of lists'});
-        }
-      } else {
-        // recursively expand value with key as new active property
-        expandedValue = api.expand({
-          activeCtx: termCtx,
-          activeProperty: key,
-          element: value,
-          options,
-          insideList: false,
-          expansionMap
-        });
-      }
-    }
-
-    // drop null values if property is not @value
-    if(expandedValue === null && expandedProperty !== '@value') {
-      // TODO: use `await` to support async
-      expandedValue = expansionMap({
-        unmappedValue: value,
-        expandedProperty,
-        activeCtx: termCtx,
-        activeProperty,
-        parent: element,
-        options,
-        insideList,
-        key: key,
-        expandedParent: rval
-      });
-      if(expandedValue === undefined) {
-        continue;
-      }
-    }
-
-    // convert expanded value to @list if container specifies it
-    if(expandedProperty !== '@list' && !_isList(expandedValue) &&
-      container.includes('@list')) {
-      // ensure expanded value is an array
-      expandedValue = (_isArray(expandedValue) ?
-        expandedValue : [expandedValue]);
-      expandedValue = {'@list': expandedValue};
-    }
-
-    // convert expanded value to @graph if container specifies it
-    // and value is not, itself, a graph
-    // index cases handled above
-    if(container.includes('@graph') &&
-      !container.some(key => key === '@id' || key === '@index') &&
-      !_isGraph(expandedValue)) {
-      // ensure expanded value is an array
-      expandedValue = [].concat(expandedValue);
-      expandedValue = {'@graph': expandedValue};
-    }
-
-    // FIXME: can this be merged with code above to simplify?
-    // merge in reverse properties
-    if(termCtx.mappings[key] && termCtx.mappings[key].reverse) {
-      const reverseMap = rval['@reverse'] = rval['@reverse'] || {};
-      if(!_isArray(expandedValue)) {
-        expandedValue = [expandedValue];
-      }
-      for(let ii = 0; ii < expandedValue.length; ++ii) {
-        const item = expandedValue[ii];
-        if(_isValue(item) || _isList(item)) {
-          throw new JsonLdError(
-            'Invalid JSON-LD syntax; "@reverse" value must not be a ' +
-            '@value or an @list.', 'jsonld.SyntaxError',
-            {code: 'invalid reverse property value', value: expandedValue});
-        }
-        _addValue(reverseMap, expandedProperty, item, {propertyIsArray: true});
-      }
-      continue;
-    }
-
-    // add value for property
-    // use an array except for certain keywords
-    const useArray =
-      !['@index', '@id', '@type', '@value', '@language'].includes(expandedProperty);
-    _addValue(
-      rval, expandedProperty, expandedValue, {propertyIsArray: useArray});
-  }
+  _expandObject({
+    activeCtx,
+    activeProperty,
+    expandedActiveProperty,
+    element,
+    expandedParent: rval,
+    options,
+    insideList,
+    expansionMap});
 
   // get property count on expanded output
   keys = Object.keys(rval);
@@ -599,6 +299,373 @@ api.expand = ({
 
   return rval;
 };
+
+/**
+ * Expand each key and value of element adding to result
+ *
+ * @param activeCtx the context to use.
+ * @param activeProperty the property for the element.
+ * @param expandedActiveProperty the expansion of activeProperty
+ * @param element the element to expand.
+ * @param expandedParent the expanded result into which to add values.
+ * @param options the expansion options.
+ * @param insideList true if the element is a list, false if not.
+ * @param expansionMap(info) a function that can be used to custom map
+ *          unmappable values (or to throw an error when they are detected);
+ *          if this function returns `undefined` then the default behavior
+ *          will be used.
+ */
+function _expandObject({
+  activeCtx,
+  activeProperty,
+  expandedActiveProperty,
+  element,
+  expandedParent,
+  options = {},
+  insideList,
+  expansionMap
+}) {
+  const keys = Object.keys(element).sort();
+  const nests = [];
+  for(const key of keys) {
+    let value = element[key];
+    let expandedValue;
+
+    // skip @context
+    if(key === '@context') {
+      continue;
+    }
+
+    // expand property
+    let expandedProperty = _expandIri(activeCtx, key, {vocab: true});
+
+    // drop non-absolute IRI keys that aren't keywords unless custom mapped
+    if(expandedProperty === null ||
+      !(_isAbsoluteIri(expandedProperty) || _isKeyword(expandedProperty))) {
+      // TODO: use `await` to support async
+      expandedProperty = expansionMap({
+        unmappedProperty: key,
+        activeCtx,
+        activeProperty,
+        parent: element,
+        options,
+        insideList,
+        value,
+        expandedParent
+      });
+      if(expandedProperty === undefined) {
+        continue;
+      }
+    }
+
+    if(_isKeyword(expandedProperty)) {
+      if(expandedActiveProperty === '@reverse') {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; a keyword cannot be used as a @reverse ' +
+          'property.', 'jsonld.SyntaxError',
+          {code: 'invalid reverse property map', value: value});
+      }
+      if(expandedProperty in expandedParent) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; colliding keywords detected.',
+          'jsonld.SyntaxError',
+          {code: 'colliding keywords', keyword: expandedProperty});
+      }
+    }
+
+    // syntax error if @id is not a string
+    if(expandedProperty === '@id' && !_isString(value)) {
+      if(!options.isFrame) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; "@id" value must a string.',
+          'jsonld.SyntaxError', {code: 'invalid @id value', value: value});
+      }
+      if(!_isObject(value)) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; "@id" value must be a string or an ' +
+          'object.', 'jsonld.SyntaxError',
+          {code: 'invalid @id value', value: value});
+      }
+    }
+
+    if(expandedProperty === '@type') {
+      _validateTypeValue(value);
+    }
+
+    // @graph must be an array or an object
+    if(expandedProperty === '@graph' &&
+      !(_isObject(value) || _isArray(value))) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; "@graph" value must not be an ' +
+        'object or an array.',
+        'jsonld.SyntaxError', {code: 'invalid @graph value', value: value});
+    }
+
+    // @value must not be an object or an array
+    if(expandedProperty === '@value' &&
+      (_isObject(value) || _isArray(value))) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; "@value" value must not be an ' +
+        'object or an array.',
+        'jsonld.SyntaxError',
+        {code: 'invalid value object value', value: value});
+    }
+
+    // @language must be a string
+    if(expandedProperty === '@language') {
+      if(value === null) {
+        // drop null @language values, they expand as if they didn't exist
+        continue;
+      }
+      if(!_isString(value)) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; "@language" value must be a string.',
+          'jsonld.SyntaxError',
+          {code: 'invalid language-tagged string', value: value});
+      }
+      // ensure language value is lowercase
+      value = value.toLowerCase();
+    }
+
+    // @index must be a string
+    if(expandedProperty === '@index') {
+      if(!_isString(value)) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; "@index" value must be a string.',
+          'jsonld.SyntaxError',
+          {code: 'invalid @index value', value: value});
+      }
+    }
+
+    // @reverse must be an object
+    if(expandedProperty === '@reverse') {
+      if(!_isObject(value)) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; "@reverse" value must be an object.',
+          'jsonld.SyntaxError', {code: 'invalid @reverse value', value: value});
+      }
+
+      expandedValue = api.expand({
+        activeCtx,
+        activeProperty:
+        '@reverse',
+        element: value,
+        options,
+        expansionMap
+      });
+      // properties double-reversed
+      if('@reverse' in expandedValue) {
+        for(let property in expandedValue['@reverse']) {
+          _addValue(
+            expandedParent, property, expandedValue['@reverse'][property],
+            {propertyIsArray: true});
+        }
+      }
+
+      // FIXME: can this be merged with code below to simplify?
+      // merge in all reversed properties
+      let reverseMap = expandedParent['@reverse'] || null;
+      for(let property in expandedValue) {
+        if(property === '@reverse') {
+          continue;
+        }
+        if(reverseMap === null) {
+          reverseMap = expandedParent['@reverse'] = {};
+        }
+        _addValue(reverseMap, property, [], {propertyIsArray: true});
+        const items = expandedValue[property];
+        for(let ii = 0; ii < items.length; ++ii) {
+          const item = items[ii];
+          if(_isValue(item) || _isList(item)) {
+            throw new JsonLdError(
+              'Invalid JSON-LD syntax; "@reverse" value must not be a ' +
+              '@value or an @list.', 'jsonld.SyntaxError',
+              {code: 'invalid reverse property value', value: expandedValue});
+          }
+          _addValue(reverseMap, property, item, {propertyIsArray: true});
+        }
+      }
+
+      continue;
+    }
+
+    // nested keys
+    if(expandedProperty === '@nest') {
+      nests.push(key);
+      continue;
+    }
+
+    // use potential scoped context for key
+    let termCtx = activeCtx;
+    const ctx = _getContextValue(activeCtx, key, '@context');
+    if(ctx) {
+      termCtx = _processContext({activeCtx, localCtx: ctx, options});
+    }
+
+    const container = _getContextValue(termCtx, key, '@container') || [];
+
+    if(container.includes('@language') && _isObject(value)) {
+      // handle language map container (skip if value is not an object)
+      expandedValue = _expandLanguageMap(termCtx, value);
+    } else if(container.includes('@index') && _isObject(value)) {
+      // handle index container (skip if value is not an object)
+      const asGraph = container.includes('@graph');
+      expandedValue = _expandIndexMap({
+        activeCtx: termCtx,
+        options,
+        activeProperty: key,
+        value,
+        expansionMap,
+        asGraph,
+        indexKey: '@index'
+      });
+    } else if(container.includes('@id') && _isObject(value)) {
+      // handle id container (skip if value is not an object)
+      const asGraph = container.includes('@graph');
+      expandedValue = _expandIndexMap({
+        activeCtx: termCtx,
+        options,
+        activeProperty: key,
+        value,
+        expansionMap,
+        asGraph,
+        indexKey: '@id'
+      });
+    } else if(container.includes('@type') && _isObject(value)) {
+      // handle type container (skip if value is not an object)
+      expandedValue = _expandIndexMap({
+        activeCtx,
+        options,
+        activeProperty: key,
+        value,
+        expansionMap,
+        asGraph: false,
+        indexKey: '@type'
+      });
+    } else {
+      // recurse into @list or @set
+      const isList = (expandedProperty === '@list');
+      if(isList || expandedProperty === '@set') {
+        let nextActiveProperty = activeProperty;
+        if(isList && expandedActiveProperty === '@graph') {
+          nextActiveProperty = null;
+        }
+        expandedValue = api.expand({
+          activeCtx: termCtx,
+          activeProperty: nextActiveProperty,
+          element: value,
+          options,
+          insideList: isList,
+          expansionMap
+        });
+        if(isList && _isList(expandedValue)) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; lists of lists are not permitted.',
+            'jsonld.SyntaxError', {code: 'list of lists'});
+        }
+      } else {
+        // recursively expand value with key as new active property
+        expandedValue = api.expand({
+          activeCtx: termCtx,
+          activeProperty: key,
+          element: value,
+          options,
+          insideList: false,
+          expansionMap
+        });
+      }
+    }
+
+    // drop null values if property is not @value
+    if(expandedValue === null && expandedProperty !== '@value') {
+      // TODO: use `await` to support async
+      expandedValue = expansionMap({
+        unmappedValue: value,
+        expandedProperty,
+        activeCtx: termCtx,
+        activeProperty,
+        parent: element,
+        options,
+        insideList,
+        key: key,
+        expandedParent
+      });
+      if(expandedValue === undefined) {
+        continue;
+      }
+    }
+
+    // convert expanded value to @list if container specifies it
+    if(expandedProperty !== '@list' && !_isList(expandedValue) &&
+      container.includes('@list')) {
+      // ensure expanded value is an array
+      expandedValue = (_isArray(expandedValue) ?
+        expandedValue : [expandedValue]);
+      expandedValue = {'@list': expandedValue};
+    }
+
+    // convert expanded value to @graph if container specifies it
+    // and value is not, itself, a graph
+    // index cases handled above
+    if(container.includes('@graph') &&
+      !container.some(key => key === '@id' || key === '@index') &&
+      !_isGraph(expandedValue)) {
+      // ensure expanded value is an array
+      expandedValue = [].concat(expandedValue);
+      expandedValue = {'@graph': expandedValue};
+    }
+
+    // FIXME: can this be merged with code above to simplify?
+    // merge in reverse properties
+    if(termCtx.mappings[key] && termCtx.mappings[key].reverse) {
+      const reverseMap = expandedParent['@reverse'] = expandedParent['@reverse'] || {};
+      if(!_isArray(expandedValue)) {
+        expandedValue = [expandedValue];
+      }
+      for(let ii = 0; ii < expandedValue.length; ++ii) {
+        const item = expandedValue[ii];
+        if(_isValue(item) || _isList(item)) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; "@reverse" value must not be a ' +
+            '@value or an @list.', 'jsonld.SyntaxError',
+            {code: 'invalid reverse property value', value: expandedValue});
+        }
+        _addValue(reverseMap, expandedProperty, item, {propertyIsArray: true});
+      }
+      continue;
+    }
+
+    // add value for property
+    // use an array except for certain keywords
+    const useArray =
+      !['@index', '@id', '@type', '@value', '@language'].includes(expandedProperty);
+    _addValue(
+      expandedParent, expandedProperty, expandedValue, {propertyIsArray: useArray});
+  }
+
+  // expand each nested key
+  for(let key of nests) {
+    const nestedValues = _isArray(element[key]) ? element[key] : [element[key]];
+    for(let nv of nestedValues) {
+      if(!_isObject(nv) ||
+        Object.keys(nv).some(k => _expandIri(activeCtx, k, {vocab: true}) === '@value')) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; nested value must be a node object.',
+            'jsonld.SyntaxError',
+            {code: 'invalid @nest value', value: nv});
+      }
+      _expandObject({
+        activeCtx,
+        activeProperty,
+        expandedActiveProperty,
+        element: nv,
+        expandedParent,
+        options,
+        insideList,
+        expansionMap});
+    }
+  }
+}
 
 /**
  * Expands the given value by using the coercion and keyword rules in the

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -50,7 +50,7 @@ const TEST_TYPES = {
   },
   'jld:FlattenTest': {
     skip: {
-      regex: [/#t0073/, /#tn/]
+      regex: [/#t0073/]
     },
     fn: 'flatten',
     params: [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,8 +29,7 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      specVersion: ['json-ld-1.0'],
-      regex: [/#t0073/, /#t[n]/]
+      specVersion: ['json-ld-1.0']
     },
     fn: 'compact',
     params: [
@@ -41,9 +40,7 @@ const TEST_TYPES = {
     compare: compareExpectedJson
   },
   'jld:ExpandTest': {
-    skip: {
-      regex: [/#tn/]
-    },
+    skip: {},
     fn: 'expand',
     params: [
       readTestUrl('input'),

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -50,7 +50,6 @@ const TEST_TYPES = {
   },
   'jld:FlattenTest': {
     skip: {
-      regex: [/#t0073/]
     },
     fn: 'flatten',
     params: [


### PR DESCRIPTION
Note, `_expandObject` is mostly a simple re-factor of the body of `expand`.

Processing of `nests` is done at the end, rather than when encountered, which is required to produce results expected by the test suite.