### PR TITLE
Remove shortcut from compactIri when iri is a keyword

### DIFF
--- a/lib/compact.js
+++ b/lib/compact.js
@@ -393,7 +393,7 @@ api.compactIri = ({
 
   const inverseCtx = activeCtx.getInverse();
 
-  // if term is a keyword, it can may be compacted to a simple alias
+  // if term is a keyword, it may be compacted to a simple alias
   if(_isKeyword(iri) &&
     iri in inverseCtx &&
     '@none' in inverseCtx[iri] &&

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -393,6 +393,15 @@ api.compactIri = ({
 
   const inverseCtx = activeCtx.getInverse();
 
+  // if term is a keyword, it can may be compacted to a simple alias
+  if(_isKeyword(iri) &&
+    iri in inverseCtx &&
+    '@none' in inverseCtx[iri] &&
+    '@type' in inverseCtx[iri]['@none'] &&
+    '@none' in inverseCtx[iri]['@none']['@type']) {
+    return inverseCtx[iri]['@none']['@type']['@none'];
+  }
+
   // use inverse context to pick a term if iri is relative to vocab
   if(relativeTo.vocab && iri in inverseCtx) {
     const defaultLanguage = activeCtx['@language'] || '@none';

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -160,7 +160,7 @@ api.compact = ({
         }
 
         // use keyword alias and add value
-        const alias = api.compactIri({activeCtx, iri: expandedProperty});
+        const alias = api.compactIri({activeCtx, iri: expandedProperty, relativeTo: {vocab: true}});
         const isArray = _isArray(compactedValue) && expandedValue.length === 0;
         _addValue(rval, alias, compactedValue, {propertyIsArray: isArray});
         continue;
@@ -194,7 +194,7 @@ api.compact = ({
 
         if(Object.keys(compactedValue).length > 0) {
           // use keyword alias and add value
-          const alias = api.compactIri({activeCtx, iri: expandedProperty});
+          const alias = api.compactIri({activeCtx, iri: expandedProperty, relativeTo: {vocab: true}});
           _addValue(rval, alias, compactedValue);
         }
 
@@ -211,7 +211,7 @@ api.compact = ({
         }
 
         // use keyword alias and add value
-        const alias = api.compactIri({activeCtx, iri: expandedProperty});
+        const alias = api.compactIri({activeCtx, iri: expandedProperty, relativeTo: {vocab: true}});
         _addValue(rval, alias, expandedValue);
         continue;
       }
@@ -220,7 +220,7 @@ api.compact = ({
       if(expandedProperty !== '@graph' && expandedProperty !== '@list' &&
         _isKeyword(expandedProperty)) {
         // use keyword alias and add value as is
-        const alias = api.compactIri({activeCtx, iri: expandedProperty});
+        const alias = api.compactIri({activeCtx, iri: expandedProperty, relativeTo: {vocab: true}});
         _addValue(rval, alias, expandedValue);
         continue;
       }
@@ -289,12 +289,12 @@ api.compact = ({
           if(!container.includes('@list')) {
             // wrap using @list alias
             compactedItem = {
-              [api.compactIri({activeCtx, iri: '@list'})]: compactedItem
+              [api.compactIri({activeCtx, iri: '@list', relativeTo: {vocab: true}})]: compactedItem
             };
 
             // include @index from expanded @list, if any
             if('@index' in expandedItem) {
-              compactedItem[api.compactIri({activeCtx, iri: '@index'})] =
+              compactedItem[api.compactIri({activeCtx, iri: '@index', relativeTo: {vocab: true}})] =
                 expandedItem['@index'];
             }
           } else if(itemActiveProperty in rval) {
@@ -312,12 +312,12 @@ api.compact = ({
         if(isSimpleGraph && !container.includes('@graph')) {
           // wrap using @graph alias
           compactedItem = {
-            [api.compactIri({activeCtx, iri: '@graph'})]: compactedItem
+            [api.compactIri({activeCtx, iri: '@graph', relativeTo: {vocab: true}})]: compactedItem
           };
 
           // include @index from expanded @graph, if any
           if('@index' in expandedItem) {
-            compactedItem[api.compactIri({activeCtx, iri: '@index'})] =
+            compactedItem[api.compactIri({activeCtx, iri: '@index', relativeTo: {vocab: true}})] =
               expandedItem['@index'];
           }
         }
@@ -392,14 +392,6 @@ api.compactIri = ({
   }
 
   const inverseCtx = activeCtx.getInverse();
-
-  // if term is a keyword, it can only be compacted to a simple alias
-  if(_isKeyword(iri)) {
-    if(iri in inverseCtx) {
-      return inverseCtx[iri]['@none']['@type']['@none'];
-    }
-    return iri;
-  }
 
   // use inverse context to pick a term if iri is relative to vocab
   if(relativeTo.vocab && iri in inverseCtx) {
@@ -621,20 +613,20 @@ api.compactValue = ({activeCtx, activeProperty, value}) => {
 
     // preserve @index
     if(preserveIndex) {
-      rval[api.compactIri({activeCtx, iri: '@index'})] = value['@index'];
+      rval[api.compactIri({activeCtx, iri: '@index', relativeTo: {vocab: true}})] = value['@index'];
     }
 
     if('@type' in value) {
       // compact @type IRI
-      rval[api.compactIri({activeCtx, iri: '@type'})] = api.compactIri(
+      rval[api.compactIri({activeCtx, iri: '@type', relativeTo: {vocab: true}})] = api.compactIri(
         {activeCtx, iri: value['@type'], relativeTo: {vocab: true}});
     } else if('@language' in value) {
       // alias @language
-      rval[api.compactIri({activeCtx, iri: '@language'})] = value['@language'];
+      rval[api.compactIri({activeCtx, iri: '@language', relativeTo: {vocab: true}})] = value['@language'];
     }
 
     // alias @value
-    rval[api.compactIri({activeCtx, iri: '@value'})] = value['@value'];
+    rval[api.compactIri({activeCtx, iri: '@value', relativeTo: {vocab: true}})] = value['@value'];
 
     return rval;
   }
@@ -651,7 +643,7 @@ api.compactValue = ({activeCtx, activeProperty, value}) => {
   }
 
   return {
-    [api.compactIri({activeCtx, iri: '@id'})]: compacted
+    [api.compactIri({activeCtx, iri: '@id', relativeTo: {vocab: true}})]: compacted
   };
 };
 
@@ -698,7 +690,7 @@ api.removePreserve = (ctx, input, options) => {
     }
 
     // handle in-memory linked nodes
-    const idAlias = api.compactIri({activeCtx: ctx, iri: '@id'});
+    const idAlias = api.compactIri({activeCtx: ctx, iri: '@id', relativeTo: {vocab: true}});
     if(idAlias in input) {
       const id = input[idAlias];
       if(id in options.link) {

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -206,7 +206,7 @@ jsonld.compact = util.callbackify(async function(input, ctx, options) {
   // add context and/or @graph
   if(_isArray(compacted)) {
     // use '@graph' keyword
-    const graphAlias = _compactIri({activeCtx, iri: '@graph'});
+    const graphAlias = _compactIri({activeCtx, iri: '@graph', relativeTo: {vocab: true}});
     const graph = compacted;
     compacted = {};
     if(hasContext) {
@@ -224,7 +224,7 @@ jsonld.compact = util.callbackify(async function(input, ctx, options) {
 
   if(options.framing) {
     // get graph alias
-    const graph = _compactIri({activeCtx, iri: '@graph'});
+    const graph = _compactIri({activeCtx, iri: '@graph', relativeTo: {vocab: true}});
     // remove @preserve from results
     options.link = {};
     compacted[graph] = _removePreserve(activeCtx, compacted[graph], options);

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,6 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/],
       specVersion: ['json-ld-1.1']
     },
     fn: 'compact',


### PR DESCRIPTION
which was preventing cases when keyword alias had `@type` defined, as in Compact 0073.