### PR TITLE
Compact iri changes

### DIFF
--- a/lib/compact.js
+++ b/lib/compact.js
@@ -649,7 +649,7 @@ api.compactIri = ({
   for(let i = partialMatches.length - 1; i >= 0; --i) {
     const entry = partialMatches[i];
     const terms = entry.terms;
-    for(let term of terms) {
+    for(const term of terms) {
       // a CURIE is usable if:
       // 1. it has no mapping, OR
       // 2. value is null, which means we're not compacting an @value, AND

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -46,7 +46,8 @@ module.exports = api;
  * @param activeProperty the compacted property associated with the element
  *          to compact, null for none.
  * @param element the element to compact.
- * @param options the compaction options.
+ * @param options the compaction options:
+ *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
  * @param compactionMap the compaction map to use.
  *
  * @return the compacted value.
@@ -132,6 +133,9 @@ api.compact = ({
     const insideReverse = (activeProperty === '@reverse');
 
     const rval = {};
+
+    // produce a map of all subjects and name each bnode
+    const issuer = options.issuer || new util.IdentifierIssuer('_:b');
 
     if(options.link && '@id' in element) {
       // store linked element

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -653,14 +653,15 @@ api.compactIri = ({
   for(let i = partialMatches.length - 1; i >= 0; --i) {
     const entry = partialMatches[i];
     const terms = entry.terms;
-    for(let ti = 0; ti < terms.length; ++ti) {
+    for(let term of terms) {
       // a CURIE is usable if:
       // 1. it has no mapping, OR
       // 2. value is null, which means we're not compacting an @value, AND
       //   the mapping matches the IRI
-      const curie = terms[ti] + ':' + iri.substr(entry.iri.length);
-      const isUsableCurie = (!(curie in activeCtx.mappings) ||
-        (value === null && activeCtx.mappings[curie]['@id'] === iri));
+      const curie = term + ':' + iri.substr(entry.iri.length);
+      const isUsableCurie = (activeCtx.mappings[term]._prefix &&
+        (!(curie in activeCtx.mappings) ||
+        (value === null && activeCtx.mappings[curie]['@id'] === iri)));
 
       // select curie if it is shorter or the same length but lexicographically
       // less than the current choice

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -46,8 +46,7 @@ module.exports = api;
  * @param activeProperty the compacted property associated with the element
  *          to compact, null for none.
  * @param element the element to compact.
- * @param options the compaction options:
- *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
+ * @param options the compaction options.
  * @param compactionMap the compaction map to use.
  *
  * @return the compacted value.
@@ -133,9 +132,6 @@ api.compact = ({
     const insideReverse = (activeProperty === '@reverse');
 
     const rval = {};
-
-    // produce a map of all subjects and name each bnode
-    const issuer = options.issuer || new util.IdentifierIssuer('_:b');
 
     if(options.link && '@id' in element) {
       // store linked element

--- a/lib/context.js
+++ b/lib/context.js
@@ -240,7 +240,9 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
   }
 
   // convert short-hand value to object w/@id
+  let simpleTerm = false;
   if(_isString(value)) {
+    simpleTerm = true;
     value = {'@id': value};
   }
 
@@ -261,7 +263,7 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
 
   // JSON-LD 1.1 support
   if(api.processingMode(activeCtx, 1.1)) {
-    validKeys.push('@context');
+    validKeys.push('@context', '@prefix');
   }
 
   for(let kw in value) {
@@ -272,6 +274,11 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
         {code: 'invalid term definition', context: localCtx});
     }
   }
+
+  // always compute whether term has a colon as an optimization for
+  // _compactIri
+  const colon = term.indexOf(':');
+  mapping._termHasColon = (colon !== -1);
 
   if('@reverse' in value) {
     if('@id' in value) {
@@ -318,13 +325,12 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
           {code: 'invalid IRI mapping', context: localCtx});
       }
       mapping['@id'] = id;
+      // indicate if this term may be used as a compact IRI prefix
+      mapping._prefix = (!mapping._termHasColon &&
+        id.match(/[:\/\?#\[\]@]$/) &&
+        (simpleTerm || !activeCtx.processingMode || activeCtx.processingMode == 'json-ld-1.0'));
     }
   }
-
-  // always compute whether term has a colon as an optimization for
-  // _compactIri
-  const colon = term.indexOf(':');
-  mapping._termHasColon = (colon !== -1);
 
   if(!('@id' in mapping)) {
     // see if the term has a prefix
@@ -476,6 +482,24 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
       language = language.toLowerCase();
     }
     mapping['@language'] = language;
+  }
+
+  // term may be used as a prefix
+  if('@prefix' in value) {
+    if(mapping._termHasColon) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; @context @prefix used on a compact IRI term',
+        'jsonld.SyntaxError',
+        {code: 'invalid term definition', context: localCtx});
+    }
+    if(value['@prefix'] === true || value['@prefix'] === false) {
+      mapping._prefix = value['@prefix'] === true
+    } else {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; @context value for @prefix must be boolean',
+        'jsonld.SyntaxError',
+        {code: 'invalid @prefix value', context: localCtx});
+    }
   }
 
   // disallow aliasing @context and @preserve
@@ -861,6 +885,7 @@ api.isKeyword = v => {
   case '@list':
   case '@none':
   case '@omitDefault':
+  case '@prefix':
   case '@preserve':
   case '@requireAll':
   case '@reverse':

--- a/lib/context.js
+++ b/lib/context.js
@@ -492,8 +492,8 @@ api.createTermDefinition = (activeCtx, localCtx, term, defined) => {
         'jsonld.SyntaxError',
         {code: 'invalid term definition', context: localCtx});
     }
-    if(value['@prefix'] === true || value['@prefix'] === false) {
-      mapping._prefix = value['@prefix'] === true
+    if(typeof value['@prefix'] === 'boolean') {
+      mapping._prefix = value['@prefix'] === true;
     } else {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; @context value for @prefix must be boolean',

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -358,7 +358,7 @@ api.expand = ({
       // handle id container (skip if value is not an object)
       const asGraph = container.includes('@graph');
       expandedValue = _expandIndexMap({
-        activeCtx,
+        activeCtx: termCtx,
         options,
         activeProperty: key,
         value,

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -136,7 +136,8 @@ jsonld.compact = util.callbackify(async function(input, ctx, options) {
     compactArrays: true,
     graph: false,
     skipExpansion: false,
-    link: false
+    link: false,
+    issuer: new IdentifierIssuer('_:b')
   });
   if(options.link) {
     // force skip expansion when linking, "link" is not part of the public

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -96,6 +96,8 @@ const wrapper = function(jsonld) {
  *          [base] the base IRI to use.
  *          [compactArrays] true to compact arrays to single values when
  *            appropriate, false not to (default: true).
+ *          [compactToRelative] true to compact IRIs to be relative to document base,
+ *            false to keep absolute (default: true)
  *          [graph] true to always output a top-level graph (default: false).
  *          [expandContext] a context to expand with.
  *          [skipExpansion] true to assume the input is expanded and skip
@@ -134,6 +136,7 @@ jsonld.compact = util.callbackify(async function(input, ctx, options) {
   options = _setDefaults(options, {
     base: _isString(input) ? input : '',
     compactArrays: true,
+    compactToRelative: true,
     graph: false,
     skipExpansion: false,
     link: false,
@@ -143,6 +146,9 @@ jsonld.compact = util.callbackify(async function(input, ctx, options) {
     // force skip expansion when linking, "link" is not part of the public
     // API, it should only be called from framing
     options.skipExpansion = true;
+  }
+  if(!options.compactToRelative) {
+    delete options.base;
   }
 
   // expand input

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -29,7 +29,8 @@ const manifest = options.manifest || {
 const TEST_TYPES = {
   'jld:CompactTest': {
     skip: {
-      regex: [/#t0073/, /#t[anp]/]
+      specVersion: ['json-ld-1.0'],
+      regex: [/#t0073/, /#t[n]/]
     },
     fn: 'compact',
     params: [


### PR DESCRIPTION
Only uses terms with IRIs ending in a delim character, or defined with `@prefix` in 1.1 mode when creating compact IRIs.