### PR TITLE
Use "application/n-quads" for N-Quads format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonld ChangeLog
 
+### Changed
+- Use the W3C standard MIME type for N-Quads of "application/n-quads". Accept
+  "application/nquads" for compatibility.
+
 ## 0.5.17 - 2018-01-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -142,19 +142,19 @@ jsonld.frame(doc, frame, (err, framed) => {
 // (URDNA2015), see: http://json-ld.github.io/normalization/spec/
 jsonld.canonize(doc, {
   algorithm: 'URDNA2015',
-  format: 'application/nquads'
+  format: 'application/n-quads'
 }, (err, canonized) => {
   // canonized is a string that is a canonical representation of the document
   // that can be used for hashing, comparison, etc.
 });
 
 // serialize a document to N-Quads (RDF)
-jsonld.toRDF(doc, {format: 'application/nquads'}, (err, nquads) => {
-  // nquads is a string of nquads
+jsonld.toRDF(doc, {format: 'application/n-quads'}, (err, nquads) => {
+  // nquads is a string of N-Quads
 });
 
 // deserialize N-Quads (RDF) to JSON-LD
-jsonld.fromRDF(nquads, {format: 'application/nquads'}, (err, doc) => {
+jsonld.fromRDF(nquads, {format: 'application/n-quads'}, (err, doc) => {
   // doc is JSON-LD
 });
 
@@ -185,13 +185,13 @@ const flattened = await jsonld.flatten(doc);
 const framed = await jsonld.frame(doc, frame);
 
 // canonicalization (normalization)
-const canonized = await jsonld.canonize(doc, {format: 'application/nquads'});
+const canonized = await jsonld.canonize(doc, {format: 'application/n-quads'});
 
 // serialize to RDF
-const rdf = await jsonld.toRDF(doc, {format: 'application/nquads'});
+const rdf = await jsonld.toRDF(doc, {format: 'application/n-quads'});
 
 // deserialize from RDF
-const doc = await jsonld.fromRDF(nquads, {format: 'application/nquads'});
+const doc = await jsonld.fromRDF(nquads, {format: 'application/n-quads'});
 
 // register a custom promise-based RDF parser
 jsonld.registerRDFParser(contentType, async input => {

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -500,9 +500,9 @@ jsonld.link = util.callbackify(async function(input, ctx, options) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [inputFormat] the format if input is not JSON-LD:
- *            'application/nquads' for N-Quads.
+ *            'application/n-quads' for N-Quads.
  *          [format] the format if output is a string:
- *            'application/nquads' for N-Quads.
+ *            'application/n-quads' for N-Quads.
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
  * @param [callback(err, normalized)] called once the operation completes.
  *
@@ -520,7 +520,8 @@ jsonld.normalize = jsonld.canonize = util.callbackify(async function(
     algorithm: 'URDNA2015'
   });
   if('inputFormat' in options) {
-    if(options.inputFormat !== 'application/nquads') {
+    if(options.inputFormat !== 'application/n-quads' &&
+      options.inputFormat !== 'application/nquads') {
       throw new JsonLdError(
         'Unknown canonicalization input format.',
         'jsonld.CanonizeError');
@@ -549,7 +550,7 @@ jsonld.normalize = jsonld.canonize = util.callbackify(async function(
  *          format option or an RDF dataset to convert.
  * @param [options] the options to use:
  *          [format] the format if dataset param must first be parsed:
- *            'application/nquads' for N-Quads (default).
+ *            'application/n-quads' for N-Quads (default).
  *          [rdfParser] a custom RDF-parser to use to parse the dataset.
  *          [useRdfType] true to use rdf:type, false to use @type
  *            (default: false).
@@ -566,7 +567,7 @@ jsonld.fromRDF = util.callbackify(async function(dataset, options) {
 
   // set default options
   options = _setDefaults(options, {
-    format: _isString(dataset) ? 'application/nquads' : undefined
+    format: _isString(dataset) ? 'application/n-quads' : undefined
   });
 
   let {format, rdfParser} = options;
@@ -622,7 +623,7 @@ jsonld.fromRDF = util.callbackify(async function(dataset, options) {
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
  *          [format] the format to use to output a string:
- *            'application/nquads' for N-Quads.
+ *            'application/n-quads' for N-Quads.
  *          [produceGeneralizedRdf] true to output generalized RDF, false
  *            to produce only standard RDF (default: false).
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
@@ -648,7 +649,8 @@ jsonld.toRDF = util.callbackify(async function(input, options) {
   // output RDF dataset
   const dataset = _toRDF(expanded, options);
   if(options.format) {
-    if(options.format === 'application/nquads') {
+    if(options.format === 'application/n-quads' ||
+      options.format === 'application/nquads') {
       return await NQuads.serialize(dataset);
     }
     throw new JsonLdError(
@@ -975,6 +977,7 @@ jsonld.unregisterRDFParser = function(contentType) {
 };
 
 // register the N-Quads RDF parser
+jsonld.registerRDFParser('application/n-quads', NQuads.parse);
 jsonld.registerRDFParser('application/nquads', NQuads.parse);
 
 // register the RDFa API RDF parser

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -117,7 +117,21 @@ describe('other toRDF tests', () => {
     });
   });
 
-  it('should handle nquads format', done => {
+  it('should handle N-Quads format', done => {
+    const doc = {
+      '@id': 'https://example.com/',
+      'https://example.com/test': 'test'
+    };
+    jsonld.toRDF(doc, {format: 'application/n-quads'}, (err, output) => {
+      assert.ifError(err);
+      assert.equal(
+        output,
+        '<https://example.com/> <https://example.com/test> "test" .\n');
+      done();
+    });
+  });
+
+  it('should handle deprecated N-Quads format', done => {
     const doc = {
       '@id': 'https://example.com/',
       'https://example.com/test': 'test'
@@ -127,6 +141,119 @@ describe('other toRDF tests', () => {
       assert.equal(
         output,
         '<https://example.com/> <https://example.com/test> "test" .\n');
+      done();
+    });
+  });
+});
+
+describe('other fromRDF tests', () => {
+  const emptyNQuads = '';
+  const emptyRdf = [];
+
+  it('should process with options and callback', done => {
+    jsonld.fromRDF('', {}, (err, output) => {
+      assert.ifError(err);
+      assert.deepEqual(output, emptyRdf);
+      done();
+    });
+  });
+
+  it('should process with no options and callback', done => {
+    jsonld.fromRDF(emptyNQuads, (err, output) => {
+      assert.ifError(err);
+      assert.deepEqual(output, emptyRdf);
+      done();
+    });
+  });
+
+  it('should process with options and promise', done => {
+    const p = jsonld.fromRDF(emptyNQuads, {});
+    assert(p instanceof Promise);
+    p.catch(e => {
+      assert.fail();
+    }).then(output => {
+      assert.deepEqual(output, emptyRdf);
+      done();
+    });
+  });
+
+  it('should process with no options and promise', done => {
+    const p = jsonld.fromRDF(emptyNQuads);
+    assert(p instanceof Promise);
+    p.catch(e => {
+      assert.fail();
+    }).then(output => {
+      assert.deepEqual(output, emptyRdf);
+      done();
+    });
+  });
+
+  it('should fail with no args and callback', done => {
+    jsonld.fromRDF((err, output) => {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should fail with no args and promise', done => {
+    const p = jsonld.fromRDF();
+    assert(p instanceof Promise);
+    p.then(output => {
+      assert.fail();
+    }).catch(e => {
+      assert(e);
+      done();
+    })
+  });
+
+  it('should fail for bad format and callback', done => {
+    jsonld.fromRDF(emptyNQuads, {format: 'bogus'}, (err, output) => {
+      assert(err);
+      assert.equal(err.name, 'jsonld.UnknownFormat');
+      done();
+    });
+  });
+
+  it('should fail for bad format and promise', done => {
+    const p = jsonld.fromRDF(emptyNQuads, {format: 'bogus'});
+    assert(p instanceof Promise);
+    p.then(() => {
+      assert.fail();
+    }).catch(e => {
+      assert(e);
+      assert.equal(e.name, 'jsonld.UnknownFormat');
+      done();
+    });
+  });
+
+  it('should handle N-Quads format', done => {
+    const nq = '<https://example.com/> <https://example.com/test> "test" .\n';
+    jsonld.fromRDF(nq, {format: 'application/n-quads'}, (err, output) => {
+      assert.ifError(err);
+      assert.deepEqual(
+        output,
+        [{
+            '@id': 'https://example.com/',
+            'https://example.com/test': [{
+              '@value': 'test'
+            }]
+        }]);
+      done();
+    });
+  });
+
+  it('should handle deprecated N-Quads format', done => {
+    const nq = '<https://example.com/> <https://example.com/test> "test" .\n';
+    jsonld.fromRDF(nq, {format: 'application/nquads'}, (err, output) => {
+      assert.ifError(err);
+      assert.deepEqual(
+        output,
+        [{
+            '@id': 'https://example.com/',
+            'https://example.com/test': [{
+              '@value': 'test'
+            }]
+        }]);
       done();
     });
   });

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -78,7 +78,7 @@ const TEST_TYPES = {
     fn: 'fromRDF',
     params: [
       readTestNQuads('input'),
-      createTestOptions({format: 'application/nquads'})
+      createTestOptions({format: 'application/n-quads'})
     ],
     compare: compareExpectedJson
   },
@@ -86,7 +86,7 @@ const TEST_TYPES = {
     fn: 'normalize',
     params: [
       readTestUrl('input'),
-      createTestOptions({format: 'application/nquads'})
+      createTestOptions({format: 'application/n-quads'})
     ],
     compare: compareExpectedNQuads
   },
@@ -95,7 +95,7 @@ const TEST_TYPES = {
     fn: 'toRDF',
     params: [
       readTestUrl('input'),
-      createTestOptions({format: 'application/nquads'})
+      createTestOptions({format: 'application/n-quads'})
     ],
     compare: compareExpectedNQuads
   },
@@ -105,8 +105,8 @@ const TEST_TYPES = {
       readTestNQuads('action'),
       createTestOptions({
         algorithm: 'URGNA2012',
-        inputFormat: 'application/nquads',
-        format: 'application/nquads'
+        inputFormat: 'application/n-quads',
+        format: 'application/n-quads'
       })
     ],
     compare: compareExpectedNQuads
@@ -117,8 +117,8 @@ const TEST_TYPES = {
       readTestNQuads('action'),
       createTestOptions({
         algorithm: 'URDNA2015',
-        inputFormat: 'application/nquads',
-        format: 'application/nquads'
+        inputFormat: 'application/n-quads',
+        format: 'application/n-quads'
       })
     ],
     compare: compareExpectedNQuads


### PR DESCRIPTION
Bonus: add `fromRDF()` API tests similar to `toRDF()`.