### PR TITLE
Add `includeRelativeUrls` option to enable relative URLs in RDF output.

### DIFF
--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -638,7 +638,8 @@ jsonld.toRDF = util.callbackify(async function(input, options) {
 
   // set default options
   options = _setDefaults(options, {
-    base: _isString(input) ? input : ''
+    base: _isString(input) ? input : '',
+    includeRelativeUrls: false
   });
 
   // TODO: support toRDF custom map?

--- a/lib/toRdf.js
+++ b/lib/toRdf.js
@@ -62,7 +62,7 @@ api.toRDF = (input, options) => {
         graphTerm = {termType: 'NamedNode'};
       }
       graphTerm.value = graphName;
-    } else {
+    } else if(!options.includeRelativeUrls) {
       // skip relative IRIs (not valid RDF)
       continue;
     }
@@ -105,7 +105,7 @@ function _graphToRDF(dataset, graph, graphTerm, issuer, options) {
         };
 
         // skip relative IRI subjects (not valid RDF)
-        if(!_isAbsoluteIri(id)) {
+        if(!_isAbsoluteIri(id) && !options.includeRelativeUrls) {
           continue;
         }
 
@@ -116,7 +116,7 @@ function _graphToRDF(dataset, graph, graphTerm, issuer, options) {
         };
 
         // skip relative IRI predicates (not valid RDF)
-        if(!_isAbsoluteIri(property)) {
+        if(!_isAbsoluteIri(property) && !options.includeRelativeUrls) {
           continue;
         }
 
@@ -134,7 +134,7 @@ function _graphToRDF(dataset, graph, graphTerm, issuer, options) {
           // convert value or node object to triple
           const object = _objectToRDF(item);
           // skip null objects (they are relative IRIs)
-          if(object) {
+          if(options.includeRelativeUrls || object) {
             dataset.push({
               subject: subject,
               predicate: predicate,


### PR DESCRIPTION
This would allow RDF output to include relative URLs. Thoughts?

cc: @davidlehn, @gkellogg, @kidehen

see: https://lists.w3.org/Archives/Public/public-linked-json/2018Jan/0014.html

```js
const jsonld = require('jsonld');

(async () => {

const doc = {
  "@context": {
    "schema": "http://schema.org/",
    "@base": "#"  
  },
  "@id": "#BrewEats",
  "@type": "schema:Restaurant",
  "schema:name": "Brew Eats",
  "databaseId": "23987520"
};

const rdf = await jsonld.toRDF(doc, {
  format: 'application/n-quads',
  includeRelativeUrls: true
});
console.log(rdf);

})();
```

Yielding:

```
<#BrewEats> <http://schema.org/name> "Brew Eats" .
<#BrewEats> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Restaurant> .
```

I'm not sure where the overlap here is with the `produceGeneralizedRdf` flag. I was concerned that simply reusing that flag would do the wrong thing, i.e. people may want relative URLs in the output, but not blank nodes in the predicate position.