### PR TITLE
Don't always use arrays for `@graph`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # jsonld ChangeLog
 
+### Fixed
+- Don't always use arrays for `@graph`. Fixes 1.0 compatibility issue.
+
 ## 1.0.0 - 2018-02-28
 
 ### Notes

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -385,9 +385,9 @@ api.compact = ({
               nestResult, itemActiveProperty, compactedItem,
               {propertyIsArray: (!options.compactArrays || container.includes('@set'))});
           } else {
-            // wrap using @graph alias, value is always an array
-            if(!_isArray(compactedItem)) {
-              compactedItem = [compactedItem]
+            // wrap using @graph alias, remove array if only one item
+            if(_isArray(compactedItem) && compactedItem.length === 1) {
+              compactedItem = compactedItem[0];
             }
             compactedItem = {
               [api.compactIri({activeCtx, iri: '@graph', relativeTo: {vocab: true}})]: compactedItem


### PR DESCRIPTION
Fixes 1.0 compatibility issue.