### PR TITLE
Restore browserify support (fix #128)

### DIFF
--- a/browser/ignore.js
+++ b/browser/ignore.js
@@ -1,1 +1,0 @@
-// Ignore module for browserify (see package.json)

--- a/package.json
+++ b/package.json
@@ -108,13 +108,6 @@
     ]
   },
   "browser": {
-    "lib/index.js": "./lib/jsonld.js",
-    "crypto": "./browser/ignore.js",
-    "http": "./browser/ignore.js",
-    "jsonld-request": "./browser/ignore.js",
-    "request": "./browser/ignore.js",
-    "url": "./browser/ignore.js",
-    "util": "./browser/ignore.js",
-    "xmldom": "./browser/ignore.js"
+    "lib/index.js": "./dist/jsonld.js"
   }
 }


### PR DESCRIPTION
Using jsonld in a browserify-based build script does not works any more.

This PR update the `browser` key in `package.json` in order force
browserify to use the `dist` version for the browser (generated by
webpack during release process).

This solution provide browserify support without the needs to maintain
complex configuration for both webpack and browserify.
It could be less optimal in term of bundle size (for browserify use a
bundled version of jsonld), but that is better than nothing and the
modern minification tools may resolve this kind of optimization needs.