### PR TITLE
Improve active context cache performance.

### DIFF
--- a/lib/ActiveContextCache.js
+++ b/lib/ActiveContextCache.js
@@ -18,9 +18,9 @@ module.exports = class ActiveContextCache {
   }
 
   get(activeCtx, localCtx) {
-    const key = JSON.stringify(localCtx);
     const level1 = this.cache.get(activeCtx);
     if(level1) {
+      const key = JSON.stringify(localCtx);
       const result = level1.get(key);
       return result || null;
     }

--- a/lib/ActiveContextCache.js
+++ b/lib/ActiveContextCache.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -13,16 +13,16 @@ module.exports = class ActiveContextCache {
    */
   constructor(size = 100) {
     this.order = [];
-    this.cache = {};
+    this.cache = new Map();
     this.size = size;
   }
 
   get(activeCtx, localCtx) {
-    const key1 = JSON.stringify(activeCtx);
-    const key2 = JSON.stringify(localCtx);
-    const level1 = this.cache[key1];
-    if(level1 && key2 in level1) {
-      return level1[key2];
+    const key = JSON.stringify(localCtx);
+    const level1 = this.cache.get(activeCtx);
+    if(level1) {
+      const result = level1.get(key);
+      return result || null;
     }
     return null;
   }
@@ -30,14 +30,15 @@ module.exports = class ActiveContextCache {
   set(activeCtx, localCtx, result) {
     if(this.order.length === this.size) {
       const entry = this.order.shift();
-      delete this.cache[entry.activeCtx][entry.localCtx];
+      this.cache.get(entry.activeCtx).delete(entry.localCtx);
     }
-    const key1 = JSON.stringify(activeCtx);
-    const key2 = JSON.stringify(localCtx);
-    this.order.push({activeCtx: key1, localCtx: key2});
-    if(!(key1 in this.cache)) {
-      this.cache[key1] = {};
+    const key = JSON.stringify(localCtx);
+    this.order.push({activeCtx, localCtx: key});
+    let level1 = this.cache.get(activeCtx);
+    if(!level1) {
+      level1 = new Map();
+      this.cache.set(activeCtx, level1);
     }
-    this.cache[key1][key2] = clone(result);
+    level1.set(key, clone(result));
   }
 };

--- a/lib/context.js
+++ b/lib/context.js
@@ -23,6 +23,8 @@ const {
 
 const MAX_CONTEXT_URLS = 10;
 
+const INITIAL_CONTEXT_CACHE = new Map();
+
 const api = {};
 module.exports = api;
 
@@ -45,9 +47,9 @@ api.process = ({activeCtx, localCtx, options}) => {
   }
   const ctxs = _isArray(localCtx) ? localCtx : [localCtx];
 
-  // no contexts in array, clone existing context
+  // no contexts in array, return current active context w/o changes
   if(ctxs.length === 0) {
-    return activeCtx.clone();
+    return activeCtx;
   }
 
   // process each context in order, update active context
@@ -630,7 +632,13 @@ api.expandIri = (activeCtx, value, relativeTo, localCtx, defined) => {
  */
 api.getInitialContext = (options) => {
   const base = parseUrl(options.base || '');
-  return {
+  const key = JSON.stringify({base, processingMode: options.processingMode});
+  const cached = INITIAL_CONTEXT_CACHE.get(key);
+  if(cached) {
+    return cached;
+  }
+
+  const initialContext = {
     '@base': base,
     processingMode: options.processingMode,
     mappings: {},
@@ -638,6 +646,8 @@ api.getInitialContext = (options) => {
     getInverse: _createInverseContext,
     clone: _cloneActiveContext
   };
+  INITIAL_CONTEXT_CACHE.set(key, initialContext);
+  return initialContext;
 
   /**
    * Generates an inverse context for use in the compaction algorithm, if

--- a/lib/context.js
+++ b/lib/context.js
@@ -24,6 +24,7 @@ const {
 const MAX_CONTEXT_URLS = 10;
 
 const INITIAL_CONTEXT_CACHE = new Map();
+const INITIAL_CONTEXT_CACHE_MAX_SIZE = 10000;
 
 const api = {};
 module.exports = api;
@@ -646,6 +647,9 @@ api.getInitialContext = (options) => {
     getInverse: _createInverseContext,
     clone: _cloneActiveContext
   };
+  if(INITIAL_CONTEXT_CACHE.size === INITIAL_CONTEXT_CACHE_MAX_SIZE) {
+    INITIAL_CONTEXT_CACHE.delete(INITIAL_CONTEXT_CACHE.keys().next().value);
+  }
   INITIAL_CONTEXT_CACHE.set(key, initialContext);
   return initialContext;
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -647,8 +647,11 @@ api.getInitialContext = (options) => {
     getInverse: _createInverseContext,
     clone: _cloneActiveContext
   };
+  // TODO: consider using LRU cache instead
   if(INITIAL_CONTEXT_CACHE.size === INITIAL_CONTEXT_CACHE_MAX_SIZE) {
-    INITIAL_CONTEXT_CACHE.delete(INITIAL_CONTEXT_CACHE.keys().next().value);
+    // clear whole cache -- assumes scenario where the cache fills means
+    // the cache isn't being used very efficiently anyway
+    INITIAL_CONTEXT_CACHE.clear();
   }
   INITIAL_CONTEXT_CACHE.set(key, initialContext);
   return initialContext;


### PR DESCRIPTION
- Use `Map` to improve cache performance.
- Cache initial contexts based on options.