### PR TITLE
Emit only valid N-Quads from toRdf.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Use rdf-canonize to compare n-quads test results.
 - Multiple graph tests.
 - Sort `@type` when looking for scoped contexts.
+- Emit only valid N-Quads from toRdf.
+  - **Note**: This could have a performance impact.
 
 ### Changed
 - Use JSON-LD WG tests.

--- a/lib/toRdf.js
+++ b/lib/toRdf.js
@@ -32,6 +32,11 @@ const {
   isAbsolute: _isAbsoluteIri
 } = require('./url');
 
+const _HEX = '[0-9A-Fa-f]';
+const _UCHAR = '\\u' + _HEX + '{4}|\\U' + _HEX + '{8}';
+const IRIREF_RE = new RegExp('^([^\\x00-\\x20<>"{}|^`\\\\]|' + _UCHAR + ')*$');
+const LANG_RE = /^[a-zA-Z]+(-[a-zA-Z0-9]+)*$/;
+
 const api = {};
 module.exports = api;
 
@@ -56,6 +61,11 @@ api.toRDF = (input, options) => {
     if(graphName === '@default') {
       graphTerm = {termType: 'DefaultGraph', value: ''};
     } else if(_isAbsoluteIri(graphName)) {
+      // invalid graph IRI
+      if(!IRIREF_RE.test(graphName)) {
+        continue;
+      }
+
       if(graphName.startsWith('_:')) {
         graphTerm = {termType: 'BlankNode'};
       } else {
@@ -109,6 +119,11 @@ function _graphToRDF(dataset, graph, graphTerm, issuer, options) {
           continue;
         }
 
+        // invalid subject IRI
+        if(!IRIREF_RE.test(id)) {
+          continue;
+        }
+
         // RDF predicate
         const predicate = {
           termType: property.startsWith('_:') ? 'BlankNode' : 'NamedNode',
@@ -117,6 +132,11 @@ function _graphToRDF(dataset, graph, graphTerm, issuer, options) {
 
         // skip relative IRI predicates (not valid RDF)
         if(!_isAbsoluteIri(property)) {
+          continue;
+        }
+
+        // invalid predicate IRI
+        if(!IRIREF_RE.test(property)) {
           continue;
         }
 
@@ -219,6 +239,11 @@ function _objectToRDF(item) {
     let value = item['@value'];
     const datatype = item['@type'] || null;
 
+    // invalid datatype IRI
+    if(datatype && !IRIREF_RE.test(datatype)) {
+      return null;
+    }
+
     // convert to XSD datatypes as appropriate
     if(types.isBoolean(value)) {
       object.value = value.toString();
@@ -234,6 +259,9 @@ function _objectToRDF(item) {
       object.value = value.toFixed(0);
       object.datatype.value = datatype || XSD_INTEGER;
     } else if('@language' in item) {
+      if(!LANG_RE.test(item['@language'])) {
+        return null;
+      }
       object.value = value;
       object.datatype.value = datatype || RDF_LANGSTRING;
       object.language = item['@language'];
@@ -244,6 +272,12 @@ function _objectToRDF(item) {
   } else {
     // convert string/node object to RDF
     const id = types.isObject(item) ? item['@id'] : item;
+
+    // invalid object IRI
+    if(!IRIREF_RE.test(id)) {
+      return null;
+    }
+
     object.termType = id.startsWith('_:') ? 'BlankNode' : 'NamedNode';
     object.value = id;
   }

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -216,14 +216,6 @@ const TEST_TYPES = {
         /^#tli02/,
         // blank node properties
         /^#t0118/,
-        // well formed
-        /^#twf01/,
-        /^#twf02/,
-        /^#twf03/,
-        /^#twf04/,
-        /^#twf05/,
-        /^#twf06/,
-        /^#twf07/,
         // html
         /^#th001/,
         /^#th002/,


### PR DESCRIPTION
- Check for valid language format.
- Check for valid subject, predicate, object, and datatype IRIs.
- Drop invalid N-Quads.

Unsure if this should be merged as is. I think there are two issues with this:
- **performance**: In performance critical code where the input data is already known to be valid this is wasted work. One solution is to add a `skipValidation` option to `toRdf` that would just omit all validation checks.
- **error handling**: I think silently dropping invalid data is a poor idea. There should be a callback or similar when bad data is found that allows the user to choose to drop it or report errors. This would certainly be useful for debugging, but I imagine would be desired in production too.