### PR TITLE
Add asArray helper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 - Switch to eslint.
+- Optimize ensuring value is an array.
 
 ## 1.5.1 - 2019-02-01
 

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -32,6 +32,7 @@ const {
 
 const {
   addValue: _addValue,
+  asArray: _asArray,
   compareShortestLeast: _compareShortestLeast
 } = require('./util');
 
@@ -167,7 +168,7 @@ api.compact = ({
 
       // compact @id and @type(s)
       if(expandedProperty === '@id' || expandedProperty === '@type') {
-        let compactedValue = [].concat(expandedValue).map(
+        let compactedValue = _asArray(expandedValue).map(
           expandedIri => api.compactIri({
             activeCtx,
             iri: expandedIri,
@@ -491,7 +492,7 @@ api.compact = ({
               vocab: true
             });
             let types;
-            [key, ...types] = [].concat(compactedItem[typeKey] || []);
+            [key, ...types] = _asArray(compactedItem[typeKey] || []);
             switch(types.length) {
               case 0:
                 delete compactedItem[typeKey];

--- a/lib/context.js
+++ b/lib/context.js
@@ -21,6 +21,10 @@ const {
   parse: parseUrl
 } = require('./url');
 
+const {
+  asArray: _asArray
+} = require('./util');
+
 const MAX_CONTEXT_URLS = 10;
 
 const INITIAL_CONTEXT_CACHE = new Map();
@@ -693,7 +697,7 @@ api.getInitialContext = options => {
       container = [].concat(container).sort().join('');
 
       // iterate over every IRI in the mapping
-      const ids = [].concat(mapping['@id']);
+      const ids = _asArray(mapping['@id']);
       for(let ii = 0; ii < ids.length; ++ii) {
         const iri = ids[ii];
         let entry = inverse[iri];

--- a/lib/context.js
+++ b/lib/context.js
@@ -967,6 +967,9 @@ async function _retrieveContextUrls(input, options) {
     // find all URLs in the given document
     const urls = new Map();
     _findContextUrls(doc, urls, false, options.base);
+    if(urls.size === 0) {
+      return;
+    }
 
     // queue all unretrieved URLs
     const queue = [...urls.keys()].filter(u => urls.get(u) === false);

--- a/lib/context.js
+++ b/lib/context.js
@@ -22,7 +22,8 @@ const {
 } = require('./url');
 
 const {
-  asArray: _asArray
+  asArray: _asArray,
+  compareShortestLeast: _compareShortestLeast
 } = require('./util');
 
 const MAX_CONTEXT_URLS = 10;
@@ -685,7 +686,7 @@ api.getInitialContext = options => {
     // create term selections for each mapping in the context, ordered by
     // shortest and then lexicographically least
     const mappings = activeCtx.mappings;
-    const terms = Object.keys(mappings).sort(util.compareShortestLeast);
+    const terms = Object.keys(mappings).sort(_compareShortestLeast);
     for(let i = 0; i < terms.length; ++i) {
       const term = terms[i];
       const mapping = mappings[term];

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -31,8 +31,9 @@ const {
 
 const {
   addValue: _addValue,
-  validateTypeValue: _validateTypeValue,
-  getValues: _getValues
+  asArray: _asArray,
+  getValues: _getValues,
+  validateTypeValue: _validateTypeValue
 } = require('./util');
 
 const api = {};
@@ -157,7 +158,11 @@ api.expand = ({
     const expandedProperty = _expandIri(activeCtx, key, {vocab: true});
     if(expandedProperty === '@type') {
       // set scopped contexts from @type
-      const types = [].concat(element[key]).sort();
+      // avoid sorting if possible
+      const value = element[key];
+      const types =
+        Array.isArray(value) ?
+          (value.length > 1 ? value.slice().sort() : value) : [value];
       for(const type of types) {
         const ctx = _getContextValue(activeCtx, type, '@context');
         if(ctx) {
@@ -212,7 +217,7 @@ api.expand = ({
         'which can be "@type" or "@language".',
         'jsonld.SyntaxError', {code: 'invalid value object', element: rval});
     }
-    const values = rval['@value'] === null ? [] : [].concat(rval['@value']);
+    const values = rval['@value'] === null ? [] : _asArray(rval['@value']);
     const types = _getValues(rval, '@type');
 
     // drop null @values unless custom mapped
@@ -416,7 +421,7 @@ function _expandObject({
 
       _addValue(
         expandedParent, '@id',
-        [].concat(value).map(v =>
+        _asArray(value).map(v =>
           _isString(v) ? _expandIri(activeCtx, v, {base: true}) : v),
         {propertyIsArray: options.isFrame});
       continue;
@@ -426,7 +431,7 @@ function _expandObject({
       _validateTypeValue(value);
       _addValue(
         expandedParent, '@type',
-        [].concat(value).map(v =>
+        _asArray(value).map(v =>
           _isString(v) ?
             _expandIri(activeCtx, v, {base: true, vocab: true}) : v),
         {propertyIsArray: options.isFrame});
@@ -470,7 +475,7 @@ function _expandObject({
           {code: 'invalid language-tagged string', value});
       }
       // ensure language value is lowercase
-      value = [].concat(value).map(v => _isString(v) ? v.toLowerCase() : v);
+      value = _asArray(value).map(v => _isString(v) ? v.toLowerCase() : v);
 
       _addValue(
         expandedParent, '@language', value, {propertyIsArray: options.isFrame});
@@ -650,10 +655,8 @@ function _expandObject({
     // convert expanded value to @list if container specifies it
     if(expandedProperty !== '@list' && !_isList(expandedValue) &&
       container.includes('@list')) {
-      // ensure expanded value is an array
-      expandedValue = (_isArray(expandedValue) ?
-        expandedValue : [expandedValue]);
-      expandedValue = {'@list': expandedValue};
+      // ensure expanded value in @list is an array
+      expandedValue = {'@list': _asArray(expandedValue)};
     }
 
     // convert expanded value to @graph if container specifies it
@@ -662,8 +665,8 @@ function _expandObject({
     if(container.includes('@graph') &&
       !container.some(key => key === '@id' || key === '@index')) {
       // ensure expanded values are arrays
-      expandedValue = [].concat(expandedValue)
-        .map(v => _isGraph(v) ? v : {'@graph': [].concat(v)});
+      expandedValue = _asArray(expandedValue)
+        .map(v => _isGraph(v) ? v : {'@graph': _asArray(v)});
     }
 
     // FIXME: can this be merged with code above to simplify?
@@ -671,9 +674,7 @@ function _expandObject({
     if(termCtx.mappings[key] && termCtx.mappings[key].reverse) {
       const reverseMap =
         expandedParent['@reverse'] = expandedParent['@reverse'] || {};
-      if(!_isArray(expandedValue)) {
-        expandedValue = [expandedValue];
-      }
+      expandedValue = _asArray(expandedValue);
       for(let ii = 0; ii < expandedValue.length; ++ii) {
         const item = expandedValue[ii];
         if(_isValue(item) || _isList(item)) {

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -1054,10 +1054,6 @@ function _setDefaults(options, {
   documentLoader = jsonld.documentLoader,
   ...defaults
 }) {
-  if(typeof options === 'function') {
-    options = {};
-  }
-  options = options || {};
   return Object.assign({}, {documentLoader}, defaults, options);
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -74,6 +74,18 @@ api.clone = function(value) {
 };
 
 /**
+ * Ensure a value is an array. If the value is an array, it is returned.
+ * Otherwise, it is wrapped in an array.
+ *
+ * @param value the value to return as an array.
+ *
+ * @return the value as an array.
+ */
+api.asArray = function(value) {
+  return Array.isArray(value) ? value : [value];
+};
+
+/**
  * Builds an HTTP headers object for making a JSON-LD request from custom
  * headers and asserts the `accept` header isn't overridden.
  *


### PR DESCRIPTION
Fixes: https://github.com/digitalbazaar/jsonld.js/issues/262

Optimization using an `asArray()` helper.  This doesn't always use a copy like the concat code, but looks to be ok in these use cases.  Has been sitting around for a while.  There was a small measurable difference in some benchmarks IIRC.