### PR TITLE
Improve testing skip features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # jsonld ChangeLog
 
 ### Fixed
-- Use explicit id or description test skipping regexes.
+- Testing: Use explicit id and description skipping regexes.
+
+### Changed
+- Testing: Improve skip logging.
+
+### Added
+- Testing: `skip` and `only` flags in manifests.
+- Testing: `VERBOSE_SKIP=true` env var to debug skipping.
 
 ## 1.5.4 - 2019-02-28
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -66,12 +66,13 @@ module.exports = function(config) {
       devtool: 'inline-source-map',
       plugins: [
         new webpack.DefinePlugin({
-          'process.env.JSONLD_TESTS': JSON.stringify(process.env.JSONLD_TESTS),
+          'process.env.BAIL': JSON.stringify(process.env.BAIL),
+          'process.env.EARL': JSON.stringify(process.env.EARL),
           'process.env.JSONLD_BENCHMARK':
             JSON.stringify(process.env.JSONLD_BENCHMARK),
+          'process.env.JSONLD_TESTS': JSON.stringify(process.env.JSONLD_TESTS),
           'process.env.TEST_ROOT_DIR': JSON.stringify(__dirname),
-          'process.env.EARL': JSON.stringify(process.env.EARL),
-          'process.env.BAIL': JSON.stringify(process.env.BAIL)
+          'process.env.VERBOSE_SKIP': JSON.stringify(process.env.VERBOSE_SKIP)
         })
       ],
       module: {

--- a/tests/test-karma.js
+++ b/tests/test-karma.js
@@ -9,6 +9,8 @@
  *   EARL=filename
  * Bail with tests fail:
  *   BAIL=true
+ * Verbose skip reasons:
+ *   VERBOSE_SKIP=true
  * Benchmark mode:
  *   Basic:
  *   JSONLD_BENCHMARK=1
@@ -106,6 +108,7 @@ const options = {
     id: 'browser',
     filename: process.env.EARL
   },
+  verboseSkip: process.env.VERBOSE_SKIP === 'true',
   bailOnError: process.env.BAIL === 'true',
   entries,
   benchmark,

--- a/tests/test.js
+++ b/tests/test.js
@@ -9,6 +9,8 @@
  *   EARL=filename
  * Bail with tests fail:
  *   BAIL=true
+ * Verbose skip reasons:
+ *   VERBOSE_SKIP=true
  * Benchmark mode:
  *   Basic:
  *   JSONLD_BENCHMARK=1
@@ -119,6 +121,7 @@ const options = {
     id: 'node.js',
     filename: process.env.EARL
   },
+  verboseSkip: process.env.VERBOSE_SKIP === 'true',
   bailOnError: process.env.BAIL === 'true',
   entries,
   benchmark,


### PR DESCRIPTION
- Improve skip logging.
- Add `skip` and `only` flags in manifests.
- Add `VERBOSE_SKIP=true` env var to debug skipping.