### PR TITLE
Renable doc loader tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 npm-debug.log
 tests/webidl/*-new
 v8.log
+test-suites/

--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -78,9 +78,7 @@ module.exports = ({
     }
 
     const {res, body} = result;
-
     doc = {contextUrl: null, documentUrl: url, document: body || null};
-
     // handle error
     const statusText = http.STATUS_CODES[res.statusCode];
     if(res.statusCode >= 400) {

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -332,7 +332,6 @@ jsonld.expand = util.callbackify(async function(input, options) {
     options,
     expansionMap: options.expansionMap
   });
-
   // optimize away @graph with no other properties
   if(_isObject(expanded) && ('@graph' in expanded) &&
     Object.keys(expanded).length === 1) {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^13.3.0",
+    "sinon": "^7.3.2",
     "webpack": "^4.29.5",
     "webpack-cli": "^3.2.3",
     "webpack-merge": "^4.2.1"

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    mocha: true
+  },
+};

--- a/tests/test.js
+++ b/tests/test.js
@@ -96,7 +96,7 @@ if(process.env.JSONLD_TESTS) {
   entries.push(path.resolve(_top, 'tests/graph-container.js'));
   entries.push(path.resolve(_top, 'tests/new-embed-api'));
   // TODO: avoid network traffic and re-enable
-  //entries.push(path.resolve(_top, 'tests/node-document-loader-tests.js'));
+  entries.push(path.resolve(_top, 'tests/node-document-loader-tests.js'));
 }
 
 let benchmark = null;
@@ -144,3 +144,16 @@ common(options).then(() => {
 process.on('unhandledRejection', (reason, p) => {
   console.error('Unhandled Rejection at:', p, 'reason:', reason);
 });
+
+// remove test data
+//
+const http = require('http');
+// store a reference to the original request function
+const originalRequest = http.request;
+// // override the function
+http.request = function wrapMethodRequest(req) {
+  console.warn('REAL HTTP CALL MADE TO', req.host);
+  // do something with the req here
+  // call the original 'request' function
+  return originalRequest.apply(this, arguments);
+};


### PR DESCRIPTION
this simply adds a sinon mock for the calls on schema.org so we can unit test the node documentLoader with out the possibility of schema.org being down or the latency.

NOTE: 3 tests are failing on travis ci, but not any of the re-enabled ones.

- adds test-suites to .gitignore
- issues a console.warn if a test makes a real node http call
- re-enables the documentLoader tests
- stubs out an axios call so we can test the default axios calls with out making real ones.