### PR TITLE
Fix type scoped terms.

### DIFF
--- a/lib/compact.js
+++ b/lib/compact.js
@@ -143,6 +143,9 @@ api.compact = ({
 
     const rval = {};
 
+    // revert type scoped terms
+    activeCtx = activeCtx.revertTypeScopedTerms();
+
     if(options.link && '@id' in element) {
       // store linked element
       if(!options.link.hasOwnProperty(element['@id'])) {
@@ -162,10 +165,15 @@ api.compact = ({
       const compactedType = api.compactIri(
         {activeCtx, iri: type, relativeTo: {vocab: true}});
 
-      // Use any scoped context defined on this value
+      // Use any type-scoped context defined on this value
       const ctx = _getContextValue(activeCtx, compactedType, '@context');
       if(!_isUndefined(ctx)) {
-        activeCtx = _processContext({activeCtx, localCtx: ctx, options});
+        activeCtx = _processContext({
+          activeCtx,
+          localCtx: ctx,
+          options,
+          isTypeScopedContext: true
+        });
       }
     }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -484,6 +484,7 @@ api.createTermDefinition = (
   if(value['@protected'] === true ||
     (defined.get('@protected') === true && value['@protected'] !== false)) {
     activeCtx.protected[term] = true;
+    mapping.protected = true;
   }
 
   // IRI mapping now defined
@@ -982,8 +983,16 @@ api.getInitialContext = options => {
       if(mapping.isTypeScopedTerm) {
         if(mapping.previousMapping) {
           child.mappings.set(term, mapping.previousMapping);
+          if(mapping.previousMapping.protected) {
+            child.protected[term] = true;
+          } else {
+            delete child.protected[term];
+          }
         } else {
           child.mappings.delete(term);
+          if(child.protected[term]) {
+            delete child.protected[term];
+          }
         }
       }
     }

--- a/lib/context.js
+++ b/lib/context.js
@@ -44,11 +44,16 @@ api.cache = new ActiveContextCache();
  * @param options the context processing options.
  * @param isPropertyTermScopedContext `true` if `localCtx` is a scoped context
  *   from a property term.
+ * @param isTypeScopedContext `true` if `localCtx` is a scoped context
+ *   from a type.
  *
  * @return the new active context.
  */
-api.process = (
-  {activeCtx, localCtx, options, isPropertyTermScopedContext = false}) => {
+api.process = ({
+  activeCtx, localCtx, options,
+  isPropertyTermScopedContext = false,
+  isTypeScopedContext = false
+}) => {
   // normalize local context to an array of @context objects
   if(_isObject(localCtx) && '@context' in localCtx &&
     _isArray(localCtx['@context'])) {
@@ -233,7 +238,8 @@ api.process = (
     // process all other keys
     for(const key in ctx) {
       api.createTermDefinition(
-        rval, ctx, key, defined, options, isPropertyTermScopedContext);
+        rval, ctx, key, defined, options,
+        isPropertyTermScopedContext, isTypeScopedContext);
     }
 
     // cache result
@@ -259,10 +265,13 @@ api.process = (
  *   signal a warning.
  * @param isPropertyTermScopedContext `true` if `localCtx` is a scoped context
  *   from a property term.
+ * @param isTypeScopedContext `true` if `localCtx` is a scoped context
+ *   from a type.
  */
 api.createTermDefinition = (
   activeCtx, localCtx, term, defined, options,
-  isPropertyTermScopedContext = false) => {
+  isPropertyTermScopedContext = false,
+  isTypeScopedContext = false) => {
   if(defined.has(term)) {
     // term already defined
     if(defined.get(term)) {
@@ -314,7 +323,11 @@ api.createTermDefinition = (
   }
 
   // remove old mapping
+  let previousMapping = null;
   if(activeCtx.mappings.has(term)) {
+    if(isTypeScopedContext) {
+      previousMapping = activeCtx.mappings.get(term);
+    }
     activeCtx.mappings.delete(term);
   }
 
@@ -349,6 +362,11 @@ api.createTermDefinition = (
   // create new mapping
   const mapping = {};
   activeCtx.mappings.set(term, mapping);
+  if(isTypeScopedContext) {
+    activeCtx.hasTypeScopedTerms = true;
+    mapping.isTypeScopedTerm = true;
+    mapping.previousMapping = previousMapping;
+  }
   mapping.reverse = false;
 
   // make sure term definition only has expected keywords
@@ -762,6 +780,7 @@ api.getInitialContext = options => {
     inverse: null,
     getInverse: _createInverseContext,
     clone: _cloneActiveContext,
+    revertTypeScopedTerms: _revertTypeScopedTerms,
     protected: {}
   };
   // TODO: consider using LRU cache instead
@@ -937,11 +956,36 @@ api.getInitialContext = options => {
     child.inverse = null;
     child.getInverse = this.getInverse;
     child.protected = util.clone(this.protected);
+    child.revertTypeScopedTerms = this.revertTypeScopedTerms;
     if('@language' in this) {
       child['@language'] = this['@language'];
     }
     if('@vocab' in this) {
       child['@vocab'] = this['@vocab'];
+    }
+    return child;
+  }
+
+  /**
+   * Reverts any type-scoped terms in this active context to their previous
+   * mappings.
+   */
+  function _revertTypeScopedTerms() {
+    // optimization: no type-scoped terms to remove, reuse active context
+    if(!this.hasTypeScopedTerms) {
+      return this;
+    }
+    // create clone without type scoped terms
+    const child = this.clone();
+    const entries = child.mappings.entries();
+    for(const [term, mapping] of entries) {
+      if(mapping.isTypeScopedTerm) {
+        if(mapping.previousMapping) {
+          child.mappings.set(term, mapping.previousMapping);
+        } else {
+          child.mappings.delete(term);
+        }
+      }
     }
     return child;
   }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -50,6 +50,8 @@ module.exports = api;
  * @param element the element to expand.
  * @param options the expansion options.
  * @param insideList true if the element is a list, false if not.
+ * @param insideTypeContainer true if the element is inside a type container,
+ *          false if not.
  * @param expansionMap(info) a function that can be used to custom map
  *          unmappable values (or to throw an error when they are detected);
  *          if this function returns `undefined` then the default behavior
@@ -63,6 +65,7 @@ api.expand = ({
   element,
   options = {},
   insideList = false,
+  insideTypeContainer = false,
   expansionMap = () => undefined
 }) => {
   // nothing to expand
@@ -111,7 +114,8 @@ api.expand = ({
         activeProperty,
         element: element[i],
         options,
-        expansionMap
+        expansionMap,
+        insideTypeContainer
       });
       if(insideList && (_isArray(e) || _isList(e))) {
         // lists of lists are illegal
@@ -148,6 +152,11 @@ api.expand = ({
 
   // recursively expand object:
 
+  if(!insideTypeContainer) {
+    // revert type scoped terms
+    activeCtx = activeCtx.revertTypeScopedTerms();
+  }
+
   // if element has a context, process it
   if('@context' in element) {
     activeCtx = _processContext(
@@ -159,7 +168,7 @@ api.expand = ({
   for(const key of keys) {
     const expandedProperty = _expandIri(activeCtx, key, {vocab: true}, options);
     if(expandedProperty === '@type') {
-      // set scopped contexts from @type
+      // set scoped contexts from @type
       // avoid sorting if possible
       const value = element[key];
       const types =
@@ -168,7 +177,12 @@ api.expand = ({
       for(const type of types) {
         const ctx = _getContextValue(activeCtx, type, '@context');
         if(!_isUndefined(ctx)) {
-          activeCtx = _processContext({activeCtx, localCtx: ctx, options});
+          activeCtx = _processContext({
+            activeCtx,
+            localCtx: ctx,
+            options,
+            isTypeScopedContext: true
+          });
         }
       }
     }
@@ -844,7 +858,15 @@ function _expandIndexMap(
     // if indexKey is @type, there may be a context defined for it
     const ctx = _getContextValue(activeCtx, key, '@context');
     if(!_isUndefined(ctx)) {
-      activeCtx = _processContext({activeCtx, localCtx: ctx, options});
+      // TODO: check that `key` is for `@type` once property indexes
+      // are permitted -- and pass `isPropertyTermScopedContext: true` if
+      // key is a property not an `@type`
+      activeCtx = _processContext({
+        activeCtx,
+        localCtx: ctx,
+        isTypeScopedContext: true,
+        options
+      });
     }
 
     let val = value[key];
@@ -867,6 +889,7 @@ function _expandIndexMap(
       element: val,
       options,
       insideList: false,
+      insideTypeContainer: indexKey === '@type',
       expansionMap
     });
     for(let item of val) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -50,7 +50,7 @@ module.exports = api;
  * @param element the element to expand.
  * @param options the expansion options.
  * @param insideList true if the element is a list, false if not.
- * @param insideTypeContainer true if the element is inside a type container,
+ * @param insideIndex true if the element is inside an index container,
  *          false if not.
  * @param expansionMap(info) a function that can be used to custom map
  *          unmappable values (or to throw an error when they are detected);
@@ -65,7 +65,7 @@ api.expand = ({
   element,
   options = {},
   insideList = false,
-  insideTypeContainer = false,
+  insideIndex = false,
   expansionMap = () => undefined
 }) => {
   // nothing to expand
@@ -115,7 +115,7 @@ api.expand = ({
         element: element[i],
         options,
         expansionMap,
-        insideTypeContainer
+        insideIndex
       });
       if(insideList && (_isArray(e) || _isList(e))) {
         // lists of lists are illegal
@@ -152,7 +152,7 @@ api.expand = ({
 
   // recursively expand object:
 
-  if(!insideTypeContainer) {
+  if(!insideIndex) {
     // revert type scoped terms
     activeCtx = activeCtx.revertTypeScopedTerms();
   }
@@ -613,7 +613,8 @@ function _expandObject({
     } else if(container.includes('@type') && _isObject(value)) {
       // handle type container (skip if value is not an object)
       expandedValue = _expandIndexMap({
-        activeCtx: termCtx,
+        // since container is `@type`, revert type scoped terms when expanding
+        activeCtx: termCtx.revertTypeScopedTerms(),
         options,
         activeProperty: key,
         value,
@@ -854,19 +855,19 @@ function _expandIndexMap(
     indexKey}) {
   const rval = [];
   const keys = Object.keys(value).sort();
+  const isTypeIndex = indexKey === '@type';
   for(let key of keys) {
     // if indexKey is @type, there may be a context defined for it
-    const ctx = _getContextValue(activeCtx, key, '@context');
-    if(!_isUndefined(ctx)) {
-      // TODO: check that `key` is for `@type` once property indexes
-      // are permitted -- and pass `isPropertyTermScopedContext: true` if
-      // key is a property not an `@type`
-      activeCtx = _processContext({
-        activeCtx,
-        localCtx: ctx,
-        isTypeScopedContext: true,
-        options
-      });
+    if(isTypeIndex) {
+      const ctx = _getContextValue(activeCtx, key, '@context');
+      if(!_isUndefined(ctx)) {
+        activeCtx = _processContext({
+          activeCtx,
+          localCtx: ctx,
+          isTypeScopedContext: true,
+          options
+        });
+      }
     }
 
     let val = value[key];
@@ -879,7 +880,7 @@ function _expandIndexMap(
     if(indexKey === '@id') {
       // expand document relative
       key = _expandIri(activeCtx, key, {base: true}, options);
-    } else if(indexKey === '@type') {
+    } else if(isTypeIndex) {
       key = expandedKey;
     }
 
@@ -889,7 +890,7 @@ function _expandIndexMap(
       element: val,
       options,
       insideList: false,
-      insideTypeContainer: indexKey === '@type',
+      insideIndex: true,
       expansionMap
     });
     for(let item of val) {


### PR DESCRIPTION
This PR will cause `@type` scoped terms to be limited to objects that have a matching `@type` value. Without this patch, `@type` scoped terms also unexpectedly apply to anything nested (contained within the tree) of a typed object.