### PR TITLE
fix: webpack should use build result for browser instead of node entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "module": "dist/jsonld.min.js",
   "files": [
     "dist/*.js",
     "dist/*.js.map",


### PR DESCRIPTION
Signed-off-by: Richard Lea <chigix@zoho.com>