### PR TITLE
Don't swallow a graph object when expanding a graph container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.0.0 - 2019-xx-xx
 
+### Fixed
+- Expanding the value of a graph container which is already a graph object
+  generates a recursive graph object.
+- Compacting multiple nodes in a graph container places them in `@included`.
+
 ### Changed
 - Default processing mode changed to json-ld-1.1. Allows a 1.1 context to be
   used after non-1.1 contexts.

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -452,6 +452,10 @@ api.compact = async ({
             _isSimpleGraph(expandedItem)) {
             // container includes @graph but not @id or @index and value is a
             // simple graph object add compact value
+            // if compactedItem contains multiple values, it is wrapped in `@included`
+            if(_isArray(compactedItem) && compactedItem.length > 1) {
+              compactedItem = {'@included': compactedItem}
+            }
             _addValue(
               nestResult, itemActiveProperty, compactedItem, {
                 propertyIsArray:

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -711,7 +711,7 @@ async function _expandObject({
       !container.some(key => key === '@id' || key === '@index')) {
       // ensure expanded values are arrays
       expandedValue = _asArray(expandedValue)
-        .map(v => _isGraph(v) ? v : {'@graph': _asArray(v)});
+        .map(v => ({'@graph': _asArray(v)}));
     }
 
     // FIXME: can this be merged with code above to simplify?

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -41,9 +41,6 @@ const TEST_TYPES = {
         /compact-manifest.jsonld#t0105$/,
         // rel vocab
         /compact-manifest.jsonld#t0107$/,
-        // @container: @graph with multiple objects
-        /compact-manifest.jsonld#t0109$/,
-        /compact-manifest.jsonld#t0110$/,
         // @type: @none
         /compact-manifest.jsonld#ttn01$/,
         /compact-manifest.jsonld#ttn02$/,
@@ -116,11 +113,6 @@ const TEST_TYPES = {
       specVersion: ['json-ld-1.0'],
       // FIXME
       idRegex: [
-        // Don't double-expand an already expanded graph
-        /expand-manifest.jsonld#t0081$/,
-        // Double-expand an already expanded graph
-        /expand-manifest.jsonld#t0095$/,
-        /expand-manifest.jsonld#t0104$/,
         // indexed graph objects
         /expand-manifest.jsonld#t0102$/,
         // multiple graphs
@@ -424,13 +416,6 @@ const TEST_TYPES = {
       idRegex: [
         // blank node properties
         /toRdf-manifest.jsonld#t0118$/,
-        // Don't double-expand an already expanded graph
-        /toRdf-manifest.jsonld#te081$/,
-        /toRdf-manifest.jsonld#te095$/,
-        // Does not create a new graph object
-        /toRdf-manifest.jsonld#te102$/,
-        /toRdf-manifest.jsonld#te103$/,
-        /toRdf-manifest.jsonld#te104$/,
         // terms beginning with ':'
         /toRdf-manifest.jsonld#te117$/,
         /toRdf-manifest.jsonld#te118$/,


### PR DESCRIPTION
Wrap multiple objects in `@included` when compacting a graph container with multiple object values.