### PR TITLE
IRI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `@vocab` can be relative or a Compact IRI in 1.1, resolved against either a previous `@vocab`,
   `@base` or document base.
 - Better checking of absolute IRIs.
-- Terms that beging with a ':' are not considered absolute or compact IRIs.
+- Terms that beggining with a ':' are not considered absolute or compact IRIs.
 - Don't use terms with `@prefix`: false, or expanded term definitions to construct compact IRIs.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - `@vocab` can be relative or a Compact IRI in 1.1, resolved against either a previous `@vocab`,
   `@base` or document base.
 - Better checking of absolute IRIs.
-- Terms that beggining with a ':' are not considered absolute or compact IRIs.
-- Don't use terms with `@prefix`: false, or expanded term definitions to construct compact IRIs.
+- Terms that begin with a ':' are not considered absolute or compact IRIs.
+- Don't use terms with `"@prefix": false` or expanded term definitions to construct compact IRIs.
 
 ### Removed
 - **BREAKING**: Remove callback API support. This includes removing support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `@vocab` can be relative in 1.0, resolved against either a previous `@vocab`,
   `@base` or document base.
 - Better checking of absolute IRIs.
+- Terms that beging with a ':' are not considered absolute or compact IRIs.
 
 ### Removed
 - **BREAKING**: Remove callback API support. This includes removing support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   `@base` or document base.
 - Better checking of absolute IRIs.
 - Terms that beging with a ':' are not considered absolute or compact IRIs.
+- Don't use terms with `@prefix`: false, or expanded term definitions to construct compact IRIs.
 
 ### Removed
 - **BREAKING**: Remove callback API support. This includes removing support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 - Default processing mode changed to json-ld-1.1. Allows a 1.1 context to be
   used after non-1.1 contexts.
-- `@vocab` can be relative in 1.0, resolved against either a previous `@vocab`,
+- `@vocab` can be relative or a Compact IRI in 1.1, resolved against either a previous `@vocab`,
   `@base` or document base.
 - Better checking of absolute IRIs.
 - Terms that beging with a ':' are not considered absolute or compact IRIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   used after non-1.1 contexts.
 - `@vocab` can be relative in 1.0, resolved against either a previous `@vocab`,
   `@base` or document base.
+- Better checking of absolute IRIs.
 
 ### Removed
 - **BREAKING**: Remove callback API support. This includes removing support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Changed
 - Default processing mode changed to json-ld-1.1. Allows a 1.1 context to be
   used after non-1.1 contexts.
+- `@vocab` can be relative in 1.0, resolved against either a previous `@vocab`,
+  `@base` or document base.
 
 ### Removed
 - **BREAKING**: Remove callback API support. This includes removing support

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -829,7 +829,7 @@ api.compactIri = ({
   for(const [term, td] of activeCtx.mappings) {
     if(td && td._prefix && iri.startsWith(term + ':')) {
       throw new JsonLdError(
-        (`Absolute IRI "${iri}" confused with prefix "${term}".`),
+        `Absolute IRI "${iri}" confused with prefix "${term}".`,
         'jsonld.SyntaxError',
         {code: 'IRI confused with prefix', context: activeCtx});
     }

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -824,6 +824,17 @@ api.compactIri = ({
     return choice;
   }
 
+  // If iri could be confused with a compact IRI using a term in this context,
+  // signal an error
+  for(const [term, td] of activeCtx.mappings) {
+    if(iri.startsWith(term + ':') && td._prefix) {
+      throw new JsonLdError(
+        ('Absolute IRI "' + iri + '" confused with prefix "' + term + '"'),
+        'jsonld.SyntaxError',
+        {code: 'IRI confused with prefix', context: activeCtx});
+    }
+  }
+
   // compact IRI relative to base
   if(!relativeTo.vocab) {
     return _removeBase(activeCtx['@base'], iri);

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -827,9 +827,9 @@ api.compactIri = ({
   // If iri could be confused with a compact IRI using a term in this context,
   // signal an error
   for(const [term, td] of activeCtx.mappings) {
-    if(iri.startsWith(term + ':') && td._prefix) {
+    if(td._prefix && iri.startsWith(term + ':')) {
       throw new JsonLdError(
-        ('Absolute IRI "' + iri + '" confused with prefix "' + term + '"'),
+        (`Absolute IRI "${iri}" confused with prefix "${term}".`),
         'jsonld.SyntaxError',
         {code: 'IRI confused with prefix', context: activeCtx});
     }

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -827,7 +827,7 @@ api.compactIri = ({
   // If iri could be confused with a compact IRI using a term in this context,
   // signal an error
   for(const [term, td] of activeCtx.mappings) {
-    if(td._prefix && iri.startsWith(term + ':')) {
+    if(td && td._prefix && iri.startsWith(term + ':')) {
       throw new JsonLdError(
         (`Absolute IRI "${iri}" confused with prefix "${term}".`),
         'jsonld.SyntaxError',

--- a/lib/context.js
+++ b/lib/context.js
@@ -227,17 +227,14 @@ api.process = async ({
           'Invalid JSON-LD syntax; the value of "@vocab" in a ' +
           '@context must be a string or null.',
           'jsonld.SyntaxError', {code: 'invalid vocab mapping', context: ctx});
-      } else if(!_isAbsoluteIri(value)) {
-        if(api.processingMode(rval, 1.0)) {
-          throw new JsonLdError(
-            'Invalid JSON-LD syntax; the value of "@vocab" in a ' +
-            '@context must be an absolute IRI.',
-            'jsonld.SyntaxError', {code: 'invalid vocab mapping', context: ctx});
-        }
+      } else if(!_isAbsoluteIri(value) && api.processingMode(rval, 1.0)) {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; the value of "@vocab" in a ' +
+          '@context must be an absolute IRI.',
+          'jsonld.SyntaxError', {code: 'invalid vocab mapping', context: ctx});
+      } else {
         rval['@vocab'] = _expandIri(rval, value, {vocab: true, base: true},
           undefined, undefined, options);
-      } else {
-        rval['@vocab'] = value;
       }
       defined.set('@vocab', true);
     }

--- a/lib/context.js
+++ b/lib/context.js
@@ -445,9 +445,9 @@ api.createTermDefinition = (
       }
       mapping['@id'] = id;
       // indicate if this term may be used as a compact IRI prefix
-      mapping._prefix = (!mapping._termHasColon &&
-        id.match(/[:\/\?#\[\]@]$/) &&
-        (simpleTerm || api.processingMode(activeCtx, 1.0)));
+      mapping._prefix = (simpleTerm &&
+        !mapping._termHasColon &&
+        id.match(/[:\/\?#\[\]@]$/));
     }
   }
 
@@ -770,8 +770,8 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     }
 
     // use mapping if prefix is defined
-    if(activeCtx.mappings.has(prefix)) {
-      const mapping = activeCtx.mappings.get(prefix);
+    const mapping = activeCtx.mappings.get(prefix);
+    if(mapping && mapping._prefix) {
       return mapping['@id'] + suffix;
     }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -393,7 +393,7 @@ api.createTermDefinition = (
   // always compute whether term has a colon as an optimization for
   // _compactIri
   const colon = term.indexOf(':');
-  mapping._termHasColon = (colon !== -1);
+  mapping._termHasColon = (colon > 0);
 
   if('@reverse' in value) {
     if('@id' in value) {
@@ -757,7 +757,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
 
   // split value into prefix:suffix
   const colon = value.indexOf(':');
-  if(colon !== -1) {
+  if(colon > 0) {
     const prefix = value.substr(0, colon);
     const suffix = value.substr(colon + 1);
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -779,7 +779,9 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     }
 
     // already absolute IRI
-    return value;
+    if(_isAbsoluteIri(value)) {
+      return value;
+    }
   }
 
   // prepend vocab

--- a/lib/context.js
+++ b/lib/context.js
@@ -194,7 +194,7 @@ api.process = async ({
 
     // if not set explicitly, set processingMode to "json-ld-1.1"
     rval.processingMode =
-      rval.processingMode || activeCtx.processingMode || 'json-ld-1.1';
+      rval.processingMode || activeCtx.processingMode;
 
     // handle @base
     if('@base' in ctx) {
@@ -205,7 +205,7 @@ api.process = async ({
       } else if(_isAbsoluteIri(base)) {
         base = parseUrl(base);
       } else if(_isRelativeIri(base)) {
-        base = parseUrl(prependBase(activeCtx['@base'].href, base));
+        base = parseUrl(prependBase(rval['@base'].href, base));
       } else {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; the value of "@base" in a ' +
@@ -228,10 +228,14 @@ api.process = async ({
           '@context must be a string or null.',
           'jsonld.SyntaxError', {code: 'invalid vocab mapping', context: ctx});
       } else if(!_isAbsoluteIri(value)) {
-        throw new JsonLdError(
-          'Invalid JSON-LD syntax; the value of "@vocab" in a ' +
-          '@context must be an absolute IRI.',
-          'jsonld.SyntaxError', {code: 'invalid vocab mapping', context: ctx});
+        if(api.processingMode(rval, 1.0)) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; the value of "@vocab" in a ' +
+            '@context must be an absolute IRI.',
+            'jsonld.SyntaxError', {code: 'invalid vocab mapping', context: ctx});
+        }
+        rval['@vocab'] = _expandIri(rval, value, {vocab: true, base: true},
+          undefined, undefined, options);
       } else {
         rval['@vocab'] = value;
       }
@@ -1086,11 +1090,10 @@ api.getAllContexts = async (input, options) => {
  */
 api.processingMode = (activeCtx, version) => {
   if(version.toString() >= '1.1') {
-    return activeCtx.processingMode &&
+    return !activeCtx.processingMode ||
       activeCtx.processingMode >= 'json-ld-' + version.toString();
   } else {
-    return !activeCtx.processingMode ||
-      activeCtx.processingMode === 'json-ld-1.0';
+    return activeCtx.processingMode === 'json-ld-1.0';
   }
 };
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -66,7 +66,7 @@ api.prependBase = (base, iri) => {
     return iri;
   }
   // already an absolute IRI
-  if(iri.indexOf(':') !== -1) {
+  if(api.isAbsolute(iri)) {
     return iri;
   }
 

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -48,8 +48,6 @@ const TEST_TYPES = {
         /compact-manifest.jsonld#tpi04$/,
         /compact-manifest.jsonld#tpi05$/,
         /compact-manifest.jsonld#tpi06$/,
-        // IRI confusion
-        /compact-manifest.jsonld#te002$/,
         // @propogate
         /compact-manifest.jsonld#tc026$/,
         /compact-manifest.jsonld#tc027$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -111,8 +111,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#t0102$/,
         // multiple graphs
         /expand-manifest.jsonld#t0103$/,
-        // iris
-        /expand-manifest.jsonld#t0109$/,
         // terms beginning with ':'
         /expand-manifest.jsonld#t0117$/,
         /expand-manifest.jsonld#t0118$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -197,9 +197,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#tso11$/,
         // colliding keywords
         /expand-manifest.jsonld#t0114$/,
-        // vocab iri/term
-        /expand-manifest.jsonld#te046$/,
-        /expand-manifest.jsonld#te047$/,
         // included
         /expand-manifest.jsonld#tin01$/,
         /expand-manifest.jsonld#tin02$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -111,9 +111,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#t0102$/,
         // multiple graphs
         /expand-manifest.jsonld#t0103$/,
-        // terms beginning with ':'
-        /expand-manifest.jsonld#t0117$/,
-        /expand-manifest.jsonld#t0118$/,
         // terms having form of keyword
         /expand-manifest.jsonld#t0119$/,
         /expand-manifest.jsonld#t0120$/,
@@ -402,9 +399,6 @@ const TEST_TYPES = {
       idRegex: [
         // blank node properties
         /toRdf-manifest.jsonld#t0118$/,
-        // terms beginning with ':'
-        /toRdf-manifest.jsonld#te117$/,
-        /toRdf-manifest.jsonld#te118$/,
         // terms having form of keyword
         /toRdf-manifest.jsonld#te119$/,
         /toRdf-manifest.jsonld#te120$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -34,13 +34,9 @@ const TEST_TYPES = {
       idRegex: [
         // terms
         /compact-manifest.jsonld#tp001$/,
-        // rel iri
-        /compact-manifest.jsonld#t0095$/,
         // type set
         /compact-manifest.jsonld#t0104$/,
         /compact-manifest.jsonld#t0105$/,
-        // rel vocab
-        /compact-manifest.jsonld#t0107$/,
         // @type: @none
         /compact-manifest.jsonld#ttn01$/,
         /compact-manifest.jsonld#ttn02$/,
@@ -117,14 +113,8 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#t0102$/,
         // multiple graphs
         /expand-manifest.jsonld#t0103$/,
-        // rel iri
-        /expand-manifest.jsonld#t0092$/,
         // iris
         /expand-manifest.jsonld#t0109$/,
-        // rel vocab
-        /expand-manifest.jsonld#t0110$/,
-        /expand-manifest.jsonld#t0111$/,
-        /expand-manifest.jsonld#t0112$/,
         // terms beginning with ':'
         /expand-manifest.jsonld#t0117$/,
         /expand-manifest.jsonld#t0118$/,
@@ -460,10 +450,8 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#t0132$/,
         // @vocab mapping
         /toRdf-manifest.jsonld#te075$/,
-        // rel IRI
-        /toRdf-manifest.jsonld#te092$/,
         /toRdf-manifest.jsonld#te109$/,
-        /toRdf-manifest.jsonld#te110$/,
+        // Invalid Statement
         /toRdf-manifest.jsonld#te111$/,
         /toRdf-manifest.jsonld#te112$/,
         // index maps

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -32,8 +32,6 @@ const TEST_TYPES = {
       specVersion: ['json-ld-1.0'],
       // FIXME
       idRegex: [
-        // terms
-        /compact-manifest.jsonld#tp001$/,
         // type set
         /compact-manifest.jsonld#t0104$/,
         /compact-manifest.jsonld#t0105$/,
@@ -163,8 +161,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#te049$/,
         // invalid keyword alias
         /expand-manifest.jsonld#te051$/,
-        // IRI prefixes
-        /expand-manifest.jsonld#tpr29$/,
         // protected null IRI mapping
         /expand-manifest.jsonld#tpr28$/,
         // remote


### PR DESCRIPTION
- `@vocab` can be relative or a Compact IRI in 1.1, resolved against either a previous `@vocab`,
  `@base` or document base.
- Better checking of absolute IRIs.
- Terms that beging with a ':' are not considered absolute or compact IRIs.
- Don't use terms with `@prefix`: false, or expanded term definitions to construct compact IRIs.
