### PR TITLE
Improve Context Propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Compacting multiple nodes in a graph container places them in `@included`.
 - Indexing on `@type` requires `@type` to be either `@id` or `@vocab`, and
   defaults to `@id`.
+- Expanding/compacting type scoped contexts uses context before applying
+  new versions to look for type scopes.
+- 
 
 ### Changed
 - Default processing mode changed to json-ld-1.1. Allows a 1.1 context to be
@@ -20,6 +23,9 @@
 - Don't use terms with `"@prefix": false` or expanded term definitions to
   construct compact IRIs.
 - `@type` may be used as a term definition only if `"@container": "@set"`.
+- Improve support for term propagation.
+- Context propagation no longer strictly related to use for property-scoped
+  or term-scoped contexts and can be overridden.
 
 ### Removed
 - **BREAKING**: Remove callback API support. This includes removing support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
   defaults to `@id`.
 - Expanding/compacting type scoped contexts uses context before applying
   new versions to look for type scopes.
-- 
 
 ### Changed
 - Default processing mode changed to json-ld-1.1. Allows a 1.1 context to be

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -102,11 +102,11 @@ api.compact = async ({
   // use any scoped context on activeProperty
   const ctx = _getContextValue(activeCtx, activeProperty, '@context');
   if(!_isUndefined(ctx)) {
-    // Note: spec's `from term` var is named `isPropertyTermScopedContext`
     activeCtx = await _processContext({
       activeCtx,
       localCtx: ctx,
-      isPropertyTermScopedContext: true,
+      propagate: true,
+      overrideProtected: true,
       options
     });
   }
@@ -159,8 +159,26 @@ api.compact = async ({
 
     const rval = {};
 
-    // revert type scoped context
-    activeCtx = activeCtx.revertTypeScopedContext();
+    // original context before applying property-scoped and local contexts
+    const inputCtx = activeCtx;
+
+    // revert to previous context, if there is one,
+    // and element is  not a value object or a node reference
+    if(!_isValue(element) && !_isSubjectReference(element)) {
+      activeCtx = activeCtx.revertToPreviousContext();
+    }
+
+    // apply property-scoped context after reverting term-scoped context
+    const propertyScopedCtx = _getContextValue(inputCtx, activeProperty, '@context');
+    if(!_isUndefined(propertyScopedCtx)) {
+      activeCtx = await _processContext({
+        activeCtx,
+        localCtx: propertyScopedCtx,
+        propagate: true,
+        overrideProtected: true,
+        options
+      });
+    }
 
     if(options.link && '@id' in element) {
       // store linked element
@@ -185,13 +203,13 @@ api.compact = async ({
         {activeCtx: typeContext, iri: type, relativeTo: {vocab: true}});
 
       // Use any type-scoped context defined on this value
-      const ctx = _getContextValue(typeContext, compactedType, '@context');
+      const ctx = _getContextValue(inputCtx, compactedType, '@context');
       if(!_isUndefined(ctx)) {
         activeCtx = await _processContext({
           activeCtx,
           localCtx: ctx,
           options,
-          isTypeScopedContext: true
+          propagate: false
         });
       }
     }

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -169,7 +169,8 @@ api.compact = async ({
     }
 
     // apply property-scoped context after reverting term-scoped context
-    const propertyScopedCtx = _getContextValue(inputCtx, activeProperty, '@context');
+    const propertyScopedCtx =
+      _getContextValue(inputCtx, activeProperty, '@context');
     if(!_isUndefined(propertyScopedCtx)) {
       activeCtx = await _processContext({
         activeCtx,
@@ -235,7 +236,7 @@ api.compact = async ({
         const alias = api.compactIri(
           {activeCtx, iri: '@id', relativeTo: {vocab: true}});
 
-          rval[alias] = compactedValue;
+        rval[alias] = compactedValue;
         continue;
       }
 
@@ -259,7 +260,7 @@ api.compact = async ({
           activeCtx, alias, '@container') || [];
 
         // treat as array for @type if @container includes @set
-        const typeAsSet = 
+        const typeAsSet =
           container.includes('@set') &&
           _processingMode(activeCtx, 1.1);
         const isArray =

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -163,7 +163,7 @@ api.compact = async ({
     const inputCtx = activeCtx;
 
     // revert to previous context, if there is one,
-    // and element is  not a value object or a node reference
+    // and element is not a value object or a node reference
     if(!_isValue(element) && !_isSubjectReference(element)) {
       activeCtx = activeCtx.revertToPreviousContext();
     }

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -219,18 +219,13 @@ api.compact = async ({
     for(const expandedProperty of keys) {
       const expandedValue = element[expandedProperty];
 
-      // compact @id and @type(s)
-      if(expandedProperty === '@id' || expandedProperty === '@type') {
-        // if using a type-scoped context, resolve type values against previous
-        // context
-        const isType = expandedProperty === '@type';
-        const valueContext = isType ?
-          (activeCtx.previousContext || activeCtx) : activeCtx;
+      // compact @id
+      if(expandedProperty === '@id') {
         let compactedValue = _asArray(expandedValue).map(
           expandedIri => api.compactIri({
-            activeCtx: valueContext,
+            activeCtx,
             iri: expandedIri,
-            relativeTo: {vocab: isType}
+            relativeTo: {vocab: false}
           }));
         if(compactedValue.length === 1) {
           compactedValue = compactedValue[0];
@@ -238,12 +233,33 @@ api.compact = async ({
 
         // use keyword alias and add value
         const alias = api.compactIri(
-          {activeCtx, iri: expandedProperty, relativeTo: {vocab: true}});
+          {activeCtx, iri: '@id', relativeTo: {vocab: true}});
+
+          rval[alias] = compactedValue;
+        continue;
+      }
+
+      // compact @type(s)
+      if(expandedProperty === '@type') {
+        // resolve type values against previous context
+        let compactedValue = _asArray(expandedValue).map(
+          expandedIri => api.compactIri({
+            activeCtx: inputCtx,
+            iri: expandedIri,
+            relativeTo: {vocab: true}
+          }));
+        if(compactedValue.length === 1) {
+          compactedValue = compactedValue[0];
+        }
+
+        // use keyword alias and add value
+        const alias = api.compactIri(
+          {activeCtx, iri: '@type', relativeTo: {vocab: true}});
         const container = _getContextValue(
           activeCtx, alias, '@container') || [];
 
         // treat as array for @type if @container includes @set
-        const typeAsSet = isType &&
+        const typeAsSet = 
           container.includes('@set') &&
           _processingMode(activeCtx, 1.1);
         const isArray =

--- a/lib/context.js
+++ b/lib/context.js
@@ -272,14 +272,13 @@ api.process = async ({
 
     // process all other keys
     for(const key in ctx) {
-      api.createTermDefinition(
-        rval, ctx, key, defined, options,
-        isPropertyTermScopedContext);
-    }
-
-    // if context is type-scoped, ensure previous context has been set
-    if(isTypeScopedContext && !rval.previousContext) {
-      rval.previousContext = previousContext.clone();
+      api.createTermDefinition({
+        activeCtx: rval,
+        localCtx: ctx,
+        term: key,
+        defined,
+        options,
+        overrideProtected});
     }
 
     // cache result
@@ -305,9 +304,14 @@ api.process = async ({
  *   signal a warning.
  * @param overrideProtected `false` allows protected terms to be modified.
  */
-api.createTermDefinition = (
-  activeCtx, localCtx, term, defined, options,
-  overrideProtected = false) => {
+api.createTermDefinition = ({
+  activeCtx,
+  localCtx,
+  term,
+  defined,
+  options,
+  overrideProtected = false,
+}) => {
   if(defined.has(term)) {
     // term already defined
     if(defined.get(term)) {
@@ -475,7 +479,7 @@ api.createTermDefinition = (
       const prefix = term.substr(0, colon);
       if(localCtx.hasOwnProperty(prefix)) {
         // define parent prefix
-        api.createTermDefinition(activeCtx, localCtx, prefix, defined, options);
+        api.createTermDefinition({activeCtx, localCtx, term: prefix, defined, options});
       }
 
       if(activeCtx.mappings.has(prefix)) {
@@ -780,9 +784,8 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
   // define term dependency if not defined
   if(localCtx && localCtx.hasOwnProperty(value) &&
     defined.get(value) !== true) {
-    api.createTermDefinition(activeCtx, localCtx, value, defined, options);
+    api.createTermDefinition({activeCtx, localCtx, term: value, defined, options});
   }
-
 
   relativeTo = relativeTo || {};
   if(relativeTo.vocab) {
@@ -813,7 +816,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
 
     // prefix dependency not defined, define it
     if(localCtx && localCtx.hasOwnProperty(prefix)) {
-      api.createTermDefinition(activeCtx, localCtx, prefix, defined, options);
+      api.createTermDefinition({activeCtx, localCtx, term: prefix, defined, options});
     }
 
     // use mapping if prefix is defined

--- a/lib/context.js
+++ b/lib/context.js
@@ -66,7 +66,7 @@ api.process = async ({
   }
 
   // override propagate if localCtx has `@propagate`
-  if(_isObject(ctxs[0]) && '@propagate' in ctxs[0]) {
+  if(_isObject(ctxs[0]) && typeof ctxs[0]['@propagate'] === 'boolean') {
     // Retrieve early, error checking done later
     propagate = ctxs[0]['@propagate'];
   }
@@ -90,7 +90,7 @@ api.process = async ({
     // reset to initial context
     if(ctx === null) {
       // We can't nullify if there are protected terms and we're
-      // not processing a property term scoped context
+      // not allowing overrides (e.g. processing a property term scoped context)
       if(!overrideProtected &&
         Object.keys(activeCtx.protected).length !== 0) {
         const protectedMode = (options && options.protectedMode) || 'error';
@@ -259,7 +259,7 @@ api.process = async ({
       }
       if(typeof value !== 'boolean') {
         throw new JsonLdError(
-          'Invalid JSON-LD syntax; @propagate must be boolean valued',
+          'Invalid JSON-LD syntax; @propagate value must be a boolean.',
           'jsonld.SyntaxError',
           {code: 'invalid @propagate value', context: localCtx});
       }
@@ -279,7 +279,8 @@ api.process = async ({
         term: key,
         defined,
         options,
-        overrideProtected});
+        overrideProtected
+      });
     }
 
     // cache result

--- a/lib/context.js
+++ b/lib/context.js
@@ -43,7 +43,7 @@ api.cache = new ActiveContextCache();
  * @param localCtx the local context to process.
  * @param options the context processing options.
  * @param propagate `true` if `false`, retains any previously defined term,
- *   which can be rolled back when the descending into a new node object changes.
+ *   which can be rolled back when the descending into a new node object.
  * @param overrideProtected `false` allows protected terms to be modified.
  *
  * @return a Promise that resolves to the new active context.
@@ -480,7 +480,9 @@ api.createTermDefinition = ({
       const prefix = term.substr(0, colon);
       if(localCtx.hasOwnProperty(prefix)) {
         // define parent prefix
-        api.createTermDefinition({activeCtx, localCtx, term: prefix, defined, options});
+        api.createTermDefinition({
+          activeCtx, localCtx, term: prefix, defined, options
+        });
       }
 
       if(activeCtx.mappings.has(prefix)) {
@@ -785,7 +787,9 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
   // define term dependency if not defined
   if(localCtx && localCtx.hasOwnProperty(value) &&
     defined.get(value) !== true) {
-    api.createTermDefinition({activeCtx, localCtx, term: value, defined, options});
+    api.createTermDefinition({
+      activeCtx, localCtx, term: value, defined, options
+    });
   }
 
   relativeTo = relativeTo || {};
@@ -817,7 +821,9 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
 
     // prefix dependency not defined, define it
     if(localCtx && localCtx.hasOwnProperty(prefix)) {
-      api.createTermDefinition({activeCtx, localCtx, term: prefix, defined, options});
+      api.createTermDefinition({
+        activeCtx, localCtx, term: prefix, defined, options
+      });
     }
 
     // use mapping if prefix is defined

--- a/lib/context.js
+++ b/lib/context.js
@@ -263,6 +263,7 @@ api.process = async ({
           'jsonld.SyntaxError',
           {code: 'invalid @propagate value', context: localCtx});
       }
+      defined.set('@propagate', true);
     }
 
     // handle @protected; determine whether this sub-context is declaring

--- a/lib/context.js
+++ b/lib/context.js
@@ -42,17 +42,16 @@ api.cache = new ActiveContextCache();
  * @param activeCtx the current active context.
  * @param localCtx the local context to process.
  * @param options the context processing options.
- * @param isPropertyTermScopedContext `true` if `localCtx` is a scoped context
- *   from a property term.
- * @param isTypeScopedContext `true` if `localCtx` is a scoped context
- *   from a type.
+ * @param propagate `true` if `false`, retains any previously defined term,
+ *   which can be rolled back when the descending into a new node object changes.
+ * @param overrideProtected `false` allows protected terms to be modified.
  *
  * @return a Promise that resolves to the new active context.
  */
 api.process = async ({
   activeCtx, localCtx, options,
-  isPropertyTermScopedContext = false,
-  isTypeScopedContext = false
+  propagate = true,
+  overrideProtected = false,
 }) => {
   // normalize local context to an array of @context objects
   if(_isObject(localCtx) && '@context' in localCtx &&
@@ -66,27 +65,22 @@ api.process = async ({
     return activeCtx;
   }
 
-  // track the previous context
-  const previousContext = activeCtx.previousContext || activeCtx;
-
-  // if context is property scoped and there's a previous context, amend it,
-  // not the current one
-  if(isPropertyTermScopedContext && activeCtx.previousContext) {
-    // TODO: consider optimizing to a shallow copy
-    activeCtx = activeCtx.clone();
-    activeCtx.isPropertyTermScoped = true;
-    activeCtx.previousContext = await api.process({
-      activeCtx: activeCtx.previousContext,
-      localCtx: ctxs,
-      options,
-      isPropertyTermScopedContext
-    });
-    return activeCtx;
+  // override propagate if localCtx has `@propagate`
+  if(_isObject(ctxs[0]) && '@propagate' in ctxs[0]) {
+    // Retrieve early, error checking done later
+    propagate = ctxs[0]['@propagate'];
   }
 
   // process each context in order, update active context
   // on each iteration to ensure proper caching
   let rval = activeCtx;
+
+  // track the previous context
+  // If not propagating, make sure rval has a previous context
+  if(!propagate && !rval.previousContext) {
+    rval.previousContext = activeCtx.clone();
+  }
+
   for(let i = 0; i < ctxs.length; ++i) {
     let ctx = ctxs[i];
 
@@ -97,7 +91,7 @@ api.process = async ({
     if(ctx === null) {
       // We can't nullify if there are protected terms and we're
       // not processing a property term scoped context
-      if(!isPropertyTermScopedContext &&
+      if(!overrideProtected &&
         Object.keys(activeCtx.protected).length !== 0) {
         const protectedMode = (options && options.protectedMode) || 'error';
         if(protectedMode === 'error') {
@@ -134,10 +128,6 @@ api.process = async ({
           {code: 'invalid protected mode', context: localCtx, protectedMode});
       }
       rval = activeCtx = api.getInitialContext(options).clone();
-      // if context is type-scoped, ensure previous context has been set
-      if(isTypeScopedContext) {
-        rval.previousContext = previousContext.clone();
-      }
       continue;
     }
 
@@ -256,6 +246,25 @@ api.process = async ({
       defined.set('@language', true);
     }
 
+    // handle @propagate
+    // note: we've already extracted it, here we just do error checking
+    if('@propagate' in ctx) {
+      const value = ctx['@propagate'];
+      if(activeCtx.processingMode === 'json-ld-1.0') {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; @propagate not compatible with ' +
+          activeCtx.processingMode,
+          'jsonld.SyntaxError',
+          {code: 'invalid context member', context: ctx});
+      }
+      if(typeof value !== 'boolean') {
+        throw new JsonLdError(
+          'Invalid JSON-LD syntax; @propagate must be boolean valued',
+          'jsonld.SyntaxError',
+          {code: 'invalid @propagate value', context: localCtx});
+      }
+    }
+
     // handle @protected; determine whether this sub-context is declaring
     // all its terms to be "protected" (exceptions can be made on a
     // per-definition basis)
@@ -294,12 +303,11 @@ api.process = async ({
  * @param {string} [options.protectedMode="error"] - "error" to throw error
  *   on `@protected` constraint violation, "warn" to allow violations and
  *   signal a warning.
- * @param isPropertyTermScopedContext `true` if `localCtx` is a scoped context
- *   from a property term.
+ * @param overrideProtected `false` allows protected terms to be modified.
  */
 api.createTermDefinition = (
   activeCtx, localCtx, term, defined, options,
-  isPropertyTermScopedContext = false) => {
+  overrideProtected = false) => {
   if(defined.has(term)) {
     // term already defined
     if(defined.get(term)) {
@@ -699,9 +707,8 @@ api.createTermDefinition = (
       'jsonld.SyntaxError', {code: 'invalid keyword alias', context: localCtx});
   }
 
-  // FIXME if(1.1) ... ?
-  if(previousMapping && previousMapping.protected &&
-    !isPropertyTermScopedContext) {
+  // Check for overriding protected terms
+  if(previousMapping && previousMapping.protected && !overrideProtected) {
     // force new term to continue to be protected and see if the mappings would
     // be equal
     activeCtx.protected[term] = true;
@@ -776,11 +783,6 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     api.createTermDefinition(activeCtx, localCtx, value, defined, options);
   }
 
-  // if context is from a property term scoped context composed with a
-  // type-scoped context, then use previous context instead
-  if(activeCtx.isPropertyTermScoped && activeCtx.previousContext) {
-    activeCtx = activeCtx.previousContext;
-  }
 
   relativeTo = relativeTo || {};
   if(relativeTo.vocab) {
@@ -862,7 +864,7 @@ api.getInitialContext = options => {
     inverse: null,
     getInverse: _createInverseContext,
     clone: _cloneActiveContext,
-    revertTypeScopedContext: _revertTypeScopedContext,
+    revertToPreviousContext: _revertToPreviousContext,
     protected: {}
   };
   // TODO: consider using LRU cache instead
@@ -1039,10 +1041,9 @@ api.getInitialContext = options => {
     child.getInverse = this.getInverse;
     child.protected = util.clone(this.protected);
     if(this.previousContext) {
-      child.isPropertyTermScoped = this.previousContext.isPropertyTermScoped;
       child.previousContext = this.previousContext.clone();
     }
-    child.revertTypeScopedContext = this.revertTypeScopedContext;
+    child.revertToPreviousContext = this.revertToPreviousContext;
     if('@language' in this) {
       child['@language'] = this['@language'];
     }
@@ -1056,7 +1057,7 @@ api.getInitialContext = options => {
    * Reverts any type-scoped context in this active context to the previous
    * context.
    */
-  function _revertTypeScopedContext() {
+  function _revertToPreviousContext() {
     if(!this.previousContext) {
       return this;
     }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -157,6 +157,9 @@ api.expand = async ({
   const expandedActiveProperty = _expandIri(
     activeCtx, activeProperty, {vocab: true}, options);
 
+  // Get any property-scoped context for activeProperty
+  const propertyScopedCtx = _getContextValue(activeCtx, activeProperty, '@context');
+
   // second, determine if any type-scoped context should be reverted; it
   // should only be reverted when the following are all true:
   // 1. `element` is not a value or subject reference
@@ -186,7 +189,18 @@ api.expand = async ({
 
   if(mustRevert) {
     // revert type scoped context
-    activeCtx = activeCtx.revertTypeScopedContext();
+    activeCtx = activeCtx.revertToPreviousContext();
+  }
+
+  // apply property-scoped context after reverting term-scoped context
+  if(!_isUndefined(propertyScopedCtx)) {
+    activeCtx = await _processContext({
+      activeCtx,
+      localCtx: propertyScopedCtx,
+      propagate: true,
+      overrideProtected: true,
+      options
+    });
   }
 
   // if element has a context, process it
@@ -370,6 +384,7 @@ api.expand = async ({
  * @param expandedParent the expanded result into which to add values.
  * @param options the expansion options.
  * @param insideList true if the element is a list, false if not.
+ * @param typeScopedContext the context before reverting.
  * @param expansionMap(info) a function that can be used to custom map
  *          unmappable values (or to throw an error when they are detected);
  *          if this function returns `undefined` then the default behavior
@@ -383,6 +398,7 @@ async function _expandObject({
   expandedParent,
   options = {},
   insideList,
+  typeScopedContext,
   expansionMap
 }) {
   const keys = Object.keys(element).sort();
@@ -593,11 +609,11 @@ async function _expandObject({
     let termCtx = activeCtx;
     const ctx = _getContextValue(activeCtx, key, '@context');
     if(!_isUndefined(ctx)) {
-      // Note: spec's `from term` var is named `isPropertyTermScopedContext`
       termCtx = await _processContext({
         activeCtx,
         localCtx: ctx,
-        isPropertyTermScopedContext: true,
+        propagate: true,
+        overrideProtected: true,
         options
       });
     }
@@ -640,7 +656,7 @@ async function _expandObject({
       // handle type container (skip if value is not an object)
       expandedValue = await _expandIndexMap({
         // since container is `@type`, revert type scoped context when expanding
-        activeCtx: termCtx.revertTypeScopedContext(),
+        activeCtx: termCtx.revertToPreviousContext(),
         options,
         activeProperty: key,
         value,
@@ -907,7 +923,7 @@ async function _expandIndexMap(
         activeCtx = await _processContext({
           activeCtx,
           localCtx: ctx,
-          isTypeScopedContext: true,
+          propagate: false,
           options
         });
       }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -158,7 +158,8 @@ api.expand = async ({
     activeCtx, activeProperty, {vocab: true}, options);
 
   // Get any property-scoped context for activeProperty
-  const propertyScopedCtx = _getContextValue(activeCtx, activeProperty, '@context');
+  const propertyScopedCtx =
+    _getContextValue(activeCtx, activeProperty, '@context');
 
   // second, determine if any type-scoped context should be reverted; it
   // should only be reverted when the following are all true:

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -209,6 +209,9 @@ api.expand = async ({
       {activeCtx, localCtx: element['@context'], options});
   }
 
+  // set the type-scoped context to the context on input, for use later
+  typeScopedContext = activeCtx;
+
   // look for scoped contexts on `@type`
   for(const key of keys) {
     const expandedProperty = _expandIri(activeCtx, key, {vocab: true}, options);
@@ -220,14 +223,13 @@ api.expand = async ({
         Array.isArray(value) ?
           (value.length > 1 ? value.slice().sort() : value) : [value];
       for(const type of types) {
-        const ctx = _getContextValue(
-          activeCtx.previousContext || activeCtx, type, '@context');
+        const ctx = _getContextValue(typeScopedContext, type, '@context');
         if(!_isUndefined(ctx)) {
           activeCtx = await _processContext({
             activeCtx,
             localCtx: ctx,
             options,
-            isTypeScopedContext: true
+            propagate: false
           });
         }
       }
@@ -494,7 +496,7 @@ async function _expandObject({
         expandedParent, '@type',
         _asArray(value).map(v =>
           _isString(v) ?
-            _expandIri(activeCtx.previousContext || activeCtx, v,
+            _expandIri(typeScopedContext, v,
               {base: true, vocab: true}, options) : v),
         {propertyIsArray: options.isFrame});
       continue;

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -38,9 +38,6 @@ const TEST_TYPES = {
         /compact-manifest.jsonld#ttn03$/,
         // IRI confusion
         /compact-manifest.jsonld#te002$/,
-        // @propogate
-        /compact-manifest.jsonld#tc026$/,
-        /compact-manifest.jsonld#tc027$/,
         // included
         /compact-manifest.jsonld#tin01$/,
         /compact-manifest.jsonld#tin02$/,
@@ -149,19 +146,13 @@ const TEST_TYPES = {
         /remote-doc-manifest.jsonld#t0013$/,
         /remote-doc-manifest.jsonld#tla01$/,
         /remote-doc-manifest.jsonld#tla05$/,
-        // @propogate
-        /expand-manifest.jsonld#tc026$/,
-        /expand-manifest.jsonld#tc027$/,
-        /expand-manifest.jsonld#tc028$/,
-        /expand-manifest.jsonld#tc029$/,
-        /expand-manifest.jsonld#tc030$/,
         // @import
         /expand-manifest.jsonld#tso01$/,
         /expand-manifest.jsonld#tso02$/,
         /expand-manifest.jsonld#tso03$/,
         /expand-manifest.jsonld#tso05$/,
         /expand-manifest.jsonld#tso06$/,
-        // protected
+        // @import and protected
         /expand-manifest.jsonld#tso07$/,
         // context merging
         /expand-manifest.jsonld#tso08$/,
@@ -365,12 +356,6 @@ const TEST_TYPES = {
       idRegex: [
         // blank node properties
         /toRdf-manifest.jsonld#t0118$/,
-        // @propogate
-        /toRdf-manifest.jsonld#tc026$/,
-        /toRdf-manifest.jsonld#tc027$/,
-        /toRdf-manifest.jsonld#tc028$/,
-        /toRdf-manifest.jsonld#tc029$/,
-        /toRdf-manifest.jsonld#tc030$/,
         // terms having form of keyword
         /toRdf-manifest.jsonld#te119$/,
         /toRdf-manifest.jsonld#te120$/,
@@ -424,7 +409,7 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#tpi09$/,
         /toRdf-manifest.jsonld#tpi10$/,
         /toRdf-manifest.jsonld#tpi11$/,
-        // protected
+        // protected null IRI mapping
         /toRdf-manifest.jsonld#tpr28$/,
         // prefix
         /toRdf-manifest.jsonld#tpr29$/,
@@ -432,10 +417,9 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#tso01$/,
         /toRdf-manifest.jsonld#tso02$/,
         /toRdf-manifest.jsonld#tso03$/,
-        // @propogate
         /toRdf-manifest.jsonld#tso05$/,
         /toRdf-manifest.jsonld#tso06$/,
-        // protected
+        // @import and protected
         /toRdf-manifest.jsonld#tso07$/,
         // context merging
         /toRdf-manifest.jsonld#tso08$/,


### PR DESCRIPTION
* Use `propagate` and `overrideProtected` options instead of `isTypeScopedContext`/`isPropertyScopedContext`.
* Change createTermDefinition method signature to use hash-based arguments, allowing optional arguments to be passed in.
* Separate processing `@id` and `@type` in expansion, due to differing rules.
* Avoid creating a term definition for `@propagate`. Enables many `@propagate` tests.

Note, this changed context processing fairly substantially.