### PR TITLE
Fix JSON literal value version 1 check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # jsonld ChangeLog
 
+### Fixed
+- JSON literal value handling issues.
+
 ## 2.0.0 - 2019-12-09
 
 ### Notes

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -406,6 +406,7 @@ async function _expandObject({
 }) {
   const keys = Object.keys(element).sort();
   const nests = [];
+  let unexpandedValue;
   for(const key of keys) {
     let value = element[key];
     let expandedValue;
@@ -513,6 +514,9 @@ async function _expandObject({
     }
 
     if(expandedProperty === '@value') {
+      // capture value for later
+      // "colliding keywords" check prevents this from being set twice
+      unexpandedValue = value;
       _addValue(
         expandedParent, '@value', value, {propertyIsArray: options.isFrame});
       continue;
@@ -770,16 +774,16 @@ async function _expandObject({
   // @value must not be an object or an array (unless framing) or if @type is
   // @json
   if('@value' in expandedParent) {
-    const value = expandedParent['@value'];
     if(expandedParent['@type'] === '@json' && _processingMode(activeCtx, 1.1)) {
       // allow any value, to be verified when the object is fully expanded and
       // the @type is @json.
-    } else if((_isObject(value) || _isArray(value)) && !options.isFrame) {
+    } else if((_isObject(unexpandedValue) || _isArray(unexpandedValue)) &&
+      !options.isFrame) {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; "@value" value must not be an ' +
         'object or an array.',
         'jsonld.SyntaxError',
-        {code: 'invalid value object value', value});
+        {code: 'invalid value object value', value: unexpandedValue});
     }
   }
 

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -769,9 +769,9 @@ async function _expandObject({
 
   // @value must not be an object or an array (unless framing) or if @type is
   // @json
-  if('@value' in element) {
-    const value = element['@value'];
-    if(element['@type'] === '@json' && _processingMode(activeCtx, 1.1)) {
+  if('@value' in expandedParent) {
+    const value = expandedParent['@value'];
+    if(expandedParent['@type'] === '@json' && _processingMode(activeCtx, 1.1)) {
       // allow any value, to be verified when the object is fully expanded and
       // the @type is @json.
     } else if((_isObject(value) || _isArray(value)) && !options.isFrame) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -762,12 +762,9 @@ async function _expandObject({
     }
 
     // add value for property
-    // use an array except for certain keywords
-    const useArray =
-      !['@index', '@id', '@type', '@value', '@language']
-        .includes(expandedProperty);
+    // special keywords handled above
     _addValue(expandedParent, expandedProperty, expandedValue, {
-      propertyIsArray: useArray
+      propertyIsArray: true
     });
   }
 


### PR DESCRIPTION
So this fixes a bug where the JSON literal version 1 check was being performed on the unexpanded input instead of on the expanded output. IOW, it was looking for `@value` on the unexpanded input and then doing some version 1 check on it if `@type` was not `@json`. If the input uses an alias for `@type` (like `type`) this check will be erroneously triggered and throw an error. Example input:

```
{
  "@context": {
    "type": "@type"
  },
  "ex:foo": {
    "type": "@json",
    "@value": {test: 1}
  }
}
```

The conditional should have been checking for `@type` on the expanded output (`expandedParent`) instead -- a similar problem would have occurred if `@value` had been aliased.

However, in fixing this bug we start to fail some test:

`#te029 Verifies that an exception is raised in Expansion when an invalid value object value is found`

In looking at the input for that test, however, it seems like the test is wrong. The input is:

```
{
  "@type": true
}
```

Which is not a value object (there is no `@value` ... it is a top-level input). So I'm not quite sure what should be done here as I don't know what that test was suppose to test originally.