### PR TITLE
Miscellaneous changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Changed
 - Keep term definitions mapping to null so they may be protected.
+- **NOTE**: `LINK_HEADER_REL` in `lib/constants.js` has been deprecated and
+  renamed to `LINK_HEADER_CONTEXT`. It remains for now but will be removed in a
+  future release.
 
 ## 2.0.2 - 2020-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - JSON literal value handling issues (`null` and `[]`).
 - Always pass typeScopedContext to _expandObject.
 - Allow a keyword to exist when expanding in _expandObject when the key is `@included` or `@type`.
+- Improve isDouble to look for big integers.
 
 ## 2.0.2 - 2020-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 - JSON literal value handling issues.
+- Do minimal checking to see if IRIs are valid by making sure they contain
+  no whitespace.
 
 ## 2.0.0 - 2019-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - JSON literal value handling issues.
 - Do minimal checking to see if IRIs are valid by making sure they contain
   no whitespace.
+- Terms of the form of an IRI must map to the same IRI.
+- Terms of the form of a relative IRI may not be used as prefixes.
 
 ## 2.0.0 - 2019-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Terms of the form of an IRI must map to the same IRI.
 - Terms of the form of a relative IRI may not be used as prefixes.
 
+### Changed
+- Keep term definitions mapping to null so they may be protected.
+
 ## 2.0.0 - 2019-12-09
 
 ### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Always pass typeScopedContext to _expandObject.
 - Allow a keyword to exist when expanding in _expandObject when the key is `@included` or `@type`.
 - Improve isDouble to look for big integers.
+- URI removeDotSegments only ensures preceding '/' if was already absolute.
 
 ## 2.0.2 - 2020-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonld ChangeLog
 
+### Fixed
+- Always pass typeScopedContext to _expandObject.
+- Allow a keyword to exist when expanding in _expandObject when the key is `@included` or `@type`.
+
 ## 2.0.2 - 2020-01-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,18 @@
 ### Fixed
 - More support for `"@type": "@none"`.
 - JSON literal value handling issues (`null` and `[]`).
-- Always pass typeScopedContext to _expandObject.
-- Allow a keyword to exist when expanding in _expandObject when the key is `@included` or `@type`.
-- Improve isDouble to look for big integers.
-- URI removeDotSegments only ensures preceding '/' if was already absolute.
+- Always pass `typeScopedContext` to `_expandObject`.
+- Allow a keyword to exist when expanding in `_expandObject` when the key is
+  `@included` or `@type`.
+- Improve `isDouble` to look for big integers.
+- URI `removeDotSegments` only ensures preceding '/' if was already absolute.
+- Do minimal checking to see if IRIs are valid by making sure they contain no
+  whitespace.
+- Terms of the form of an IRI must map to the same IRI.
+- Terms of the form of a relative IRI may not be used as prefixes.
+
+### Changed
+- Keep term definitions mapping to null so they may be protected.
 
 ## 2.0.2 - 2020-01-17
 
@@ -22,13 +30,6 @@
 
 ### Fixed
 - JSON literal value handling issues.
-- Do minimal checking to see if IRIs are valid by making sure they contain
-  no whitespace.
-- Terms of the form of an IRI must map to the same IRI.
-- Terms of the form of a relative IRI may not be used as prefixes.
-
-### Changed
-- Keep term definitions mapping to null so they may be protected.
 
 ## 2.0.0 - 2019-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # jsonld ChangeLog
 
 ### Fixed
+- More support for `"@type": "@none"`.
+- JSON literal value handling issues (`null` and `[]`).
 - Always pass typeScopedContext to _expandObject.
 - Allow a keyword to exist when expanding in _expandObject when the key is `@included` or `@type`.
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,7 +7,7 @@ const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
 module.exports = {
-  LINK_HEADER_REL: 'http://www.w3.org/ns/json-ld#context',
+  LINK_HEADER_CONTEXT: 'http://www.w3.org/ns/json-ld#context',
 
   RDF,
   RDF_LIST: RDF + 'List',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,6 +7,9 @@ const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
 module.exports = {
+  // TODO: Deprecated and will be removed later. Use LINK_HEADER_CONTEXT.
+  LINK_HEADER_REL: 'http://www.w3.org/ns/json-ld#context',
+
   LINK_HEADER_CONTEXT: 'http://www.w3.org/ns/json-ld#context',
 
   RDF,

--- a/lib/context.js
+++ b/lib/context.js
@@ -365,16 +365,9 @@ api.createTermDefinition = ({
     activeCtx.mappings.delete(term);
   }
 
-  // clear context entry
-  if(value === null || (_isObject(value) && value['@id'] === null)) {
-    activeCtx.mappings.set(term, null);
-    defined.set(term, true);
-    return;
-  }
-
   // convert short-hand value to object w/@id
   let simpleTerm = false;
-  if(_isString(value)) {
+  if(_isString(value) || value === null) {
     simpleTerm = true;
     value = {'@id': value};
   }
@@ -448,13 +441,16 @@ api.createTermDefinition = ({
     mapping.reverse = true;
   } else if('@id' in value) {
     let id = value['@id'];
-    if(!_isString(id)) {
+    if(id && !_isString(id)) {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; a @context @id value must be an array ' +
         'of strings or a string.',
         'jsonld.SyntaxError', {code: 'invalid IRI mapping', context: localCtx});
     }
-    if(id !== term) {
+    if(id === null) {
+      // reserve a null term, which may be protected
+      mapping['@id'] = null;
+    } else if(id !== term) {
       // expand and add @id mapping
       id = _expandIri(
         activeCtx, id, {vocab: true, base: false}, localCtx, defined, options);
@@ -470,10 +466,12 @@ api.createTermDefinition = ({
       if(term.match(/(?::[^:])|\//)) {
         const termDefined = new Map(defined).set(term, true);
         const termIri = _expandIri(
-          activeCtx, term, {vocab: true, base: false}, localCtx, termDefined, options);
+          activeCtx, term, {vocab: true, base: false},
+          localCtx, termDefined, options);
         if(termIri !== id) {
           throw new JsonLdError(
-            'Invalid JSON-LD syntax; term in form of IRI must expand to definition.',
+            'Invalid JSON-LD syntax; term in form of IRI must ' +
+            'expand to definition.',
             'jsonld.SyntaxError',
             {code: 'invalid IRI mapping', context: localCtx});
         }
@@ -942,6 +940,9 @@ api.getInitialContext = options => {
       let container = mapping['@container'] || '@none';
       container = [].concat(container).sort().join('');
 
+      if(mapping['@id'] === null) {
+        continue;
+      }
       // iterate over every IRI in the mapping
       const ids = _asArray(mapping['@id']);
       for(const iri of ids) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -465,6 +465,20 @@ api.createTermDefinition = ({
           'jsonld.SyntaxError',
           {code: 'invalid IRI mapping', context: localCtx});
       }
+
+      // if term has the form of an IRI it must map the same
+      if(term.match(/(?::[^:])|\//)) {
+        const termDefined = new Map(defined).set(term, true);
+        const termIri = _expandIri(
+          activeCtx, term, {vocab: true, base: false}, localCtx, termDefined, options);
+        if(termIri !== id) {
+          throw new JsonLdError(
+            'Invalid JSON-LD syntax; term in form of IRI must expand to definition.',
+            'jsonld.SyntaxError',
+            {code: 'invalid IRI mapping', context: localCtx});
+        }
+      }
+
       mapping['@id'] = id;
       // indicate if this term may be used as a compact IRI prefix
       mapping._prefix = (simpleTerm &&
@@ -685,7 +699,7 @@ api.createTermDefinition = ({
 
   // term may be used as a prefix
   if('@prefix' in value) {
-    if(mapping._termHasColon) {
+    if(term.match(/:|\//)) {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; @context @prefix used on a compact IRI term',
         'jsonld.SyntaxError',
@@ -808,7 +822,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
       return null;
     }
 
-    if(mapping) {
+    if(_isObject(mapping) && '@id' in mapping) {
       // value is a term
       return mapping['@id'];
     }

--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -4,9 +4,10 @@
 'use strict';
 
 const {parseLinkHeader, buildHeaders} = require('../util');
-const {LINK_HEADER_REL} = require('../constants');
+const {LINK_HEADER_CONTEXT} = require('../constants');
 const JsonLdError = require('../JsonLdError');
 const RequestQueue = require('../RequestQueue');
+const {prependBase} = require('../url');
 
 /**
  * Creates a built-in node document loader.
@@ -61,6 +62,7 @@ module.exports = ({
     }
 
     let result;
+    let alternate = null;
     try {
       result = await _request(request, {
         url,
@@ -95,21 +97,30 @@ module.exports = ({
     if(res.headers.link &&
       res.headers['content-type'] !== 'application/ld+json') {
       // only 1 related link header permitted
-      const linkHeader = parseLinkHeader(res.headers.link)[LINK_HEADER_REL];
-      if(Array.isArray(linkHeader)) {
+      const linkHeaders = parseLinkHeader(res.headers.link);
+      const linkedContext = linkHeaders[LINK_HEADER_CONTEXT];
+      if(Array.isArray(linkedContext)) {
         throw new JsonLdError(
           'URL could not be dereferenced, it has more than one associated ' +
           'HTTP Link Header.',
           'jsonld.InvalidUrl',
           {code: 'multiple context link headers', url});
       }
-      if(linkHeader) {
-        doc.contextUrl = linkHeader.target;
+      if(linkedContext) {
+        doc.contextUrl = linkedContext.target;
+      }
+
+      // "alternate" link header is a redirect
+      alternate = linkHeaders['alternate'];
+      if(alternate &&
+        alternate.type == 'application/ld+json' &&
+        !(res.headers['content-type'] || '').match(/^application\/(\w*\+)?json$/)) {
+        res.headers.location = prependBase(url, alternate.target);
       }
     }
 
     // handle redirect
-    if(res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+    if((alternate || res.statusCode >= 300 && res.statusCode < 400) && res.headers.location) {
       if(redirects.length === maxRedirects) {
         throw new JsonLdError(
           'URL could not be dereferenced; there were too many redirects.',

--- a/lib/documentLoaders/xhr.js
+++ b/lib/documentLoaders/xhr.js
@@ -4,9 +4,10 @@
 'use strict';
 
 const {parseLinkHeader, buildHeaders} = require('../util');
-const {LINK_HEADER_REL} = require('../constants');
+const {LINK_HEADER_CONTEXT} = require('../constants');
 const JsonLdError = require('../JsonLdError');
 const RequestQueue = require('../RequestQueue');
+const {prependBase} = require('../url');
 
 const REGEX_LINK_HEADER = /(^|(\r\n))link:/i;
 
@@ -65,6 +66,7 @@ module.exports = ({
     }
 
     const doc = {contextUrl: null, documentUrl: url, document: req.response};
+    let alternate = null;
 
     // handle Link Header (avoid unsafe header warning by existence testing)
     const contentType = req.getResponseHeader('Content-Type');
@@ -74,16 +76,25 @@ module.exports = ({
     }
     if(linkHeader && contentType !== 'application/ld+json') {
       // only 1 related link header permitted
-      linkHeader = parseLinkHeader(linkHeader)[LINK_HEADER_REL];
-      if(Array.isArray(linkHeader)) {
+      const linkHeaders = parseLinkHeader(res.headers.link);
+      const linkedContext = linkHeaders[LINK_HEADER_CONTEXT];
+      if(Array.isArray(linkedContext)) {
         throw new JsonLdError(
           'URL could not be dereferenced, it has more than one ' +
           'associated HTTP Link Header.',
           'jsonld.InvalidUrl',
           {code: 'multiple context link headers', url});
       }
-      if(linkHeader) {
-        doc.contextUrl = linkHeader.target;
+      if(linkedContext) {
+        doc.contextUrl = linkedContext.target;
+      }
+
+      // "alternate" link header is a redirect
+      alternate = linkHeaders['alternate'];
+      if(alternate &&
+        alternate.type == 'application/ld+json' &&
+        !(contentType || '').match(/^application\/(\w*\+)?json$/)) {
+        doc = await loader(prependBase(url, alternate.target));
       }
     }
 

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -458,7 +458,9 @@ async function _expandObject({
           'property.', 'jsonld.SyntaxError',
           {code: 'invalid reverse property map', value});
       }
-      if(expandedProperty in expandedParent) {
+      if(expandedProperty in expandedParent &&
+        expandedProperty !== '@included' &&
+        expandedProperty !== '@type') {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; colliding keywords detected.',
           'jsonld.SyntaxError',
@@ -821,6 +823,7 @@ async function _expandObject({
         expandedParent,
         options,
         insideList,
+        typeScopedContext,
         typeKey,
         expansionMap});
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -32,7 +32,8 @@ api.isBoolean = v => (typeof v === 'boolean' ||
  *
  * @return true if the value is a double, false if not.
  */
-api.isDouble = v => api.isNumber(v) && String(v).indexOf('.') !== -1;
+api.isDouble = v => api.isNumber(v) &&
+  (String(v).indexOf('.') !== -1 || Math.abs(v) >= 1e21);
 
 /**
  * Returns true if the given value is an empty Object.

--- a/lib/url.js
+++ b/lib/url.js
@@ -262,8 +262,8 @@ api.removeDotSegments = path => {
     output.push(next);
   }
 
-  // ensure output has leading /
-  if(output.length > 0 && output[0] !== '') {
+  // if path was absolute, ensure output has leading /
+  if(path[0] === '/' && output.length > 0 && output[0] !== '') {
     output.unshift('');
   }
   if(output.length === 1 && output[0] === '') {

--- a/lib/url.js
+++ b/lib/url.js
@@ -277,7 +277,7 @@ api.removeDotSegments = path => {
 // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html
 
 // regex to check for absolute IRI (starting scheme and ':') or blank node IRI
-const isAbsoluteRegex = /^([A-Za-z][A-Za-z0-9+-.]*|_):/;
+const isAbsoluteRegex = /^([A-Za-z][A-Za-z0-9+-.]*|_):[^\s]*$/;
 
 /**
  * Returns true if the given value is an absolute IRI or blank node IRI, false

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -72,8 +72,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#t0119$/,
         /expand-manifest.jsonld#t0120$/,
         /expand-manifest.jsonld#t0122$/,
-        // invalid datatype IRI
-        /expand-manifest.jsonld#t0123$/,
         // html
         /html-manifest.jsonld#te001$/,
         /html-manifest.jsonld#te002$/,
@@ -334,8 +332,6 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#te119$/,
         /toRdf-manifest.jsonld#te120$/,
         /toRdf-manifest.jsonld#te122$/,
-        // invalid datatype IRI
-        /toRdf-manifest.jsonld#te123$/,
         // well formed
         /toRdf-manifest.jsonld#twf01$/,
         /toRdf-manifest.jsonld#twf02$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -100,8 +100,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#thc03$/,
         /expand-manifest.jsonld#thc04$/,
         /expand-manifest.jsonld#thc05$/,
-        // protected null IRI mapping
-        /expand-manifest.jsonld#tpr28$/,
         // remote
         /remote-doc-manifest.jsonld#t0005$/,
         /remote-doc-manifest.jsonld#t0006$/,
@@ -376,8 +374,6 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#tpi09$/,
         /toRdf-manifest.jsonld#tpi10$/,
         /toRdf-manifest.jsonld#tpi11$/,
-        // protected null IRI mapping
-        /toRdf-manifest.jsonld#tpr28$/,
         // prefix
         /toRdf-manifest.jsonld#tpr29$/,
         // @import

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -337,15 +337,12 @@ const TEST_TYPES = {
         /html-manifest.jsonld#tr020$/,
         /html-manifest.jsonld#tr021$/,
         /html-manifest.jsonld#tr022$/,
-        // number fixes
-        /toRdf-manifest.jsonld#trt01$/,
         // IRI resolution
         /toRdf-manifest.jsonld#t0130$/,
         /toRdf-manifest.jsonld#t0131$/,
         /toRdf-manifest.jsonld#t0132$/,
-        // @vocab mapping
-        /toRdf-manifest.jsonld#te075$/,
         // Invalid Statement
+        /toRdf-manifest.jsonld#te075$/,
         /toRdf-manifest.jsonld#te111$/,
         /toRdf-manifest.jsonld#te112$/,
         // @import

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -127,8 +127,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#tin07$/,
         /expand-manifest.jsonld#tin08$/,
         /expand-manifest.jsonld#tin09$/,
-        // @nest
-        /expand-manifest.jsonld#tn008$/,
         // keywords
         /expand-manifest.jsonld#tpr30$/,
         /expand-manifest.jsonld#tpr31$/,
@@ -390,8 +388,6 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#tin04$/,
         /toRdf-manifest.jsonld#tin05$/,
         /toRdf-manifest.jsonld#tin06$/,
-        // @next
-        /toRdf-manifest.jsonld#tn008$/,
         // keywords
         /toRdf-manifest.jsonld#tpr30$/,
         /toRdf-manifest.jsonld#tpr31$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -101,13 +101,7 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#thc04$/,
         /expand-manifest.jsonld#thc05$/,
         // remote
-        /remote-doc-manifest.jsonld#t0005$/,
-        /remote-doc-manifest.jsonld#t0006$/,
-        /remote-doc-manifest.jsonld#t0007$/,
-        /remote-doc-manifest.jsonld#t0010$/,
-        /remote-doc-manifest.jsonld#t0011$/,
-        /remote-doc-manifest.jsonld#t0012$/,
-        /remote-doc-manifest.jsonld#t0013$/,
+        /remote-doc-manifest.jsonld#t0013$/, // HTML
         /remote-doc-manifest.jsonld#tla01$/,
         /remote-doc-manifest.jsonld#tla05$/,
         // @import
@@ -1097,9 +1091,10 @@ function createDocumentLoader(test) {
   ];
   const localLoader = function(url) {
     // always load remote-doc tests remotely in node
-    if(options.nodejs && test.manifest.name === 'Remote document') {
-      return jsonld.documentLoader(url);
-    }
+    // NOTE: disabled due to github pages issues.
+    //if(options.nodejs && test.manifest.name === 'Remote document') {
+    //  return jsonld.documentLoader(url);
+    //}
 
     // FIXME: this check only works for main test suite and will not work if:
     // - running other tests and main test suite not installed

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -100,11 +100,6 @@ const TEST_TYPES = {
         /expand-manifest.jsonld#thc03$/,
         /expand-manifest.jsonld#thc04$/,
         /expand-manifest.jsonld#thc05$/,
-        // misc
-        /expand-manifest.jsonld#te043$/,
-        /expand-manifest.jsonld#te044$/,
-        /expand-manifest.jsonld#te048$/,
-        /expand-manifest.jsonld#te049$/,
         // protected null IRI mapping
         /expand-manifest.jsonld#tpr28$/,
         // remote

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -310,20 +310,12 @@ const TEST_TYPES = {
       specVersion: ['json-ld-1.0'],
       // FIXME
       idRegex: [
-        // blank node properties
-        /toRdf-manifest.jsonld#t0118$/,
         // terms having form of keyword
         /toRdf-manifest.jsonld#te119$/,
         /toRdf-manifest.jsonld#te120$/,
         /toRdf-manifest.jsonld#te122$/,
         // well formed
-        /toRdf-manifest.jsonld#twf01$/,
-        /toRdf-manifest.jsonld#twf02$/,
-        /toRdf-manifest.jsonld#twf03$/,
-        /toRdf-manifest.jsonld#twf04$/,
         /toRdf-manifest.jsonld#twf05$/,
-        /toRdf-manifest.jsonld#twf06$/,
-        /toRdf-manifest.jsonld#twf07$/,
         // html
         /html-manifest.jsonld#tr001$/,
         /html-manifest.jsonld#tr002$/,
@@ -353,20 +345,9 @@ const TEST_TYPES = {
         /toRdf-manifest.jsonld#t0132$/,
         // @vocab mapping
         /toRdf-manifest.jsonld#te075$/,
-        /toRdf-manifest.jsonld#te109$/,
         // Invalid Statement
         /toRdf-manifest.jsonld#te111$/,
         /toRdf-manifest.jsonld#te112$/,
-        // index maps
-        /toRdf-manifest.jsonld#tpi05$/,
-        /toRdf-manifest.jsonld#tpi06$/,
-        /toRdf-manifest.jsonld#tpi07$/,
-        /toRdf-manifest.jsonld#tpi08$/,
-        /toRdf-manifest.jsonld#tpi09$/,
-        /toRdf-manifest.jsonld#tpi10$/,
-        /toRdf-manifest.jsonld#tpi11$/,
-        // prefix
-        /toRdf-manifest.jsonld#tpr29$/,
         // @import
         /toRdf-manifest.jsonld#tso01$/,
         /toRdf-manifest.jsonld#tso02$/,

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -337,10 +337,6 @@ const TEST_TYPES = {
         /html-manifest.jsonld#tr020$/,
         /html-manifest.jsonld#tr021$/,
         /html-manifest.jsonld#tr022$/,
-        // IRI resolution
-        /toRdf-manifest.jsonld#t0130$/,
-        /toRdf-manifest.jsonld#t0131$/,
-        /toRdf-manifest.jsonld#t0132$/,
         // Invalid Statement
         /toRdf-manifest.jsonld#te075$/,
         /toRdf-manifest.jsonld#te111$/,


### PR DESCRIPTION
A bunch of fixes that address everything other than Framing and some toRdf tests.

- Do minimal checking to see if IRIs are valid by making sure they contain no whitespace.
(804c15b93c9ff7b1c86e965a5feaa5ba0c77b3f0)
- Terms of the form of an IRI must map to the same IRI. (280a01e16bb728f4221055e102408390400f71a1)
- Terms of the form of a relative IRI may not be used as prefixes. (280a01e16bb728f4221055e102408390400f71a1)
- Keep term definitions mapping to null so they may be protected. (2613c4a26cf91d252ae7a713e666d5a90fb78ff1)
- Use localLoader for remote tests. (ff95ee28ecb99e8148c4bcbf949cf4ff7ac767f6)
- Support `rel=alternate`. (080e37445dfc39d16a80d4c56d86ce8ea392c32c)
  - Note XHR and Node loaders don't have their own tests.
- Always pass typeScopedContext to _expandObject. (f0d80f1ee1fc04a501ca7dca7d3e0dc502e3dd24)
- Allow a keyword to exist when expanding in _expandObject when the key is `@included` or `@type`. (f0d80f1ee1fc04a501ca7dca7d3e0dc502e3dd24)