### PR TITLE
isKeyword optimization for non-keyword fast path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - JSON literal value handling issues (`null` and `[]`).
 - Fix resolving context `null` values.
 
+### Changed
+- `isKeyword()` optimization for non-keyword fast path.
+
 ## 2.0.1 - 2019-12-10
 
 ### Fixed

--- a/lib/context.js
+++ b/lib/context.js
@@ -1156,7 +1156,7 @@ api.processingMode = (activeCtx, version) => {
  * @return true if the value is a keyword, false if not.
  */
 api.isKeyword = v => {
-  if(!_isString(v)) {
+  if(!_isString(v) || v[0] !== '@') {
     return false;
   }
   switch(v) {


### PR DESCRIPTION
- Add non-keyword fast path check if first char is '@'.
- Avoids full `switch` for data that can't be a keyword.
- Array access will just be undefined for empty string.
- Performance change depends on data shape, format, and processing algorithm workload. Some synthetic tests with ~80% non-keywords could see 1-3%+ overall increase.

I tried various permutations of other `isKeyword` optimizations.  The benchmarking code had too much noise to tell what was best.  But this simple change does appear to have some effect for some (most?) workloads.  I did try a few other things, which should maybe be further explored if needed, but I couldn't tell if they were better or not:
- Change `switch` to `keywordSet.has(v)`.
- Change `switch` to `v in kewordsObject`.
- Change `switch` to `kewordsObject.hasOwnProperty(v)`.
- Moving the probably popular `@context`, `@id`, `@type` to be first in `switch` or to an earlier fast path `switch`, explicity `if` checks, or other constructs.

If someone wants to dig into the optimizer to figure out the best way to run this particular check, that could be interesting.  I think better benchmarking code is needed to check otherwise.