### PR TITLE
Handle term definition on `@type` with empty map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Terms of the form of a relative IRI may not be used as prefixes.
 - Match spec error code "invalid context entry" vs "invalid context member".
 - Keywords may not be used as prefixes.
+- Handle term definition on `@type` with empty map.
 
 ### Changed
 - Keep term definitions mapping to null so they may be protected.

--- a/lib/context.js
+++ b/lib/context.js
@@ -411,7 +411,8 @@ api.createTermDefinition = ({
      api.processingMode(activeCtx, 1.1)) {
 
     const validKeys = ['@container', '@id', '@protected'];
-    if(Object.keys(value).some(k => !validKeys.includes(k))) {
+    const keys = Object.keys(value);
+    if(keys.length === 0 || keys.some(k => !validKeys.includes(k))) {
       throw new JsonLdError(
         'Invalid JSON-LD syntax; keywords cannot be overridden.',
         'jsonld.SyntaxError',


### PR DESCRIPTION
Fixes expand#tec02 & toRdf#tec02.

@gkellogg "keyword redefinition" was not what I expected for this type of error.  Is that more appropriate than the more generic "invalid term definition"?