### PR TITLE
Fix term mapping of `@reverse`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Match spec error code "invalid context entry" vs "invalid context member".
 - Keywords may not be used as prefixes.
 - Handle term definition on `@type` with empty map.
+- Handling of `@` values for `@reverse`.
 
 ### Changed
 - Keep term definitions mapping to null so they may be protected.

--- a/lib/context.js
+++ b/lib/context.js
@@ -506,18 +506,7 @@ api.createTermDefinition = ({
         'jsonld.SyntaxError', {code: 'invalid IRI mapping', context: localCtx});
     }
 
-    // expand and add @id mapping
-    const id = _expandIri(
-      activeCtx, reverse, {vocab: true, base: false}, localCtx, defined,
-      options);
-    if(!_isAbsoluteIri(id)) {
-      throw new JsonLdError(
-        'Invalid JSON-LD syntax; a @context @reverse value must be an ' +
-        'absolute IRI or a blank node identifier.',
-        'jsonld.SyntaxError', {code: 'invalid IRI mapping', context: localCtx});
-    }
-
-    if(reverse.match(KEYWORD_PATTERN)) {
+    if(!api.isKeyword(reverse) && reverse.match(KEYWORD_PATTERN)) {
       // FIXME: remove logging and use a handler
       console.warn('WARNING: values beginning with "@" are reserved' +
         ' for future use and ignored', {reverse});
@@ -527,6 +516,17 @@ api.createTermDefinition = ({
         activeCtx.mappings.delete(term);
       }
       return;
+    }
+
+    // expand and add @id mapping
+    const id = _expandIri(
+      activeCtx, reverse, {vocab: true, base: false}, localCtx, defined,
+      options);
+    if(!_isAbsoluteIri(id)) {
+      throw new JsonLdError(
+        'Invalid JSON-LD syntax; a @context @reverse value must be an ' +
+        'absolute IRI or a blank node identifier.',
+        'jsonld.SyntaxError', {code: 'invalid IRI mapping', context: localCtx});
     }
 
     mapping['@id'] = id;


### PR DESCRIPTION
Please check.  I'm making tests pass without proper understanding of how this should be working.  Should there be some warning here or is the "ignore" behavior itself important?