### PR TITLE
Fix for: Framing does not respect specified value #300

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -596,10 +596,6 @@ function _filterSubject(state, subject, frame, flags) {
           return false;
         }
         matchThis = true;
-      } else if(types.isObject(thisFrame)) { // XXX only framing keywords
-        // node matches if values is not empty and the value of property in
-        // frame is wildcard
-        matchThis = nodeValues.length > 0;
       } else {
         if(graphTypes.isValue(thisFrame)) {
           // match on any matching value

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -460,6 +460,48 @@ describe('js keywords', () => {
     const e = await jsonld.frame(d, frame);
     assert.deepStrictEqual(e, ex);
   });
+
+  it('frame js match on value', async () => {
+    const d =
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@graph": [
+    {
+      "@id": "JOHN",
+      "@type": "Person",
+      "givenName": "John"
+    },
+    {
+      "@id": "JANE",
+      "@type": "Person",
+      "givenName": "Jane"
+    }
+  ]
+}
+;
+    const frame =
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "givenName": "John"
+}
+;
+    const ex =
+{
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
+  "@id": "JOHN",
+  "@type": "Person",
+  "givenName": "John"
+}
+;
+    const e = await jsonld.frame(d, frame);
+    assert.deepStrictEqual(e, ex);
+  });
 });
 
 describe('literal JSON', () => {


### PR DESCRIPTION
This fixes #300 to match behavior in RDF Distiller.

> Expected Behaviour: Given a document with 2 persons "Jane" and "John" and a frame for "givenName": "John" I expect the result to contain only John, but not Jane.
> 
> Actual Behaviour: The result contains both persons, just that Janes givenName is set to null

This removes the initial check on the node to see if it has any properties and falls through to check the node to see if the values match.

I added a test based on the issue.