### PR TITLE
Fix for: Framing does not respect specified value #300

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -596,19 +596,8 @@ function _filterSubject(state, subject, frame, flags) {
           return false;
         }
         matchThis = true;
-      } else if(types.isObject(thisFrame)) { // XXX only framing keywords
-        // node matches if values is not empty and the value of property in
-        // frame is wildcard
-        matchThis = nodeValues.length > 0;
       } else {
-        if(graphTypes.isValue(thisFrame)) {
-          // match on any matching value
-          matchThis = nodeValues.some(nv => _valueMatch(thisFrame, nv));
-        } else if(graphTypes.isSubject(thisFrame) ||
-          graphTypes.isSubjectReference(thisFrame)) {
-          matchThis =
-            nodeValues.some(nv => _nodeMatch(state, thisFrame, nv, flags));
-        } else if(graphTypes.isList(thisFrame)) {
+        if(graphTypes.isList(thisFrame)) {
           const listValue = thisFrame['@list'][0];
           if(graphTypes.isList(nodeValues[0])) {
             const nodeListValues = nodeValues[0]['@list'];
@@ -621,10 +610,16 @@ function _filterSubject(state, subject, frame, flags) {
               matchThis = nodeListValues.some(lv => _nodeMatch(
                 state, listValue, lv, flags));
             }
-          } else {
-            // value must be a list to match
-            matchThis = false;
           }
+        } else if(graphTypes.isValue(thisFrame)) {
+          matchThis = nodeValues.some(nv => _valueMatch(thisFrame, nv));
+        } else if(graphTypes.isSubjectReference(thisFrame)) {
+          matchThis =
+            nodeValues.some(nv => _nodeMatch(state, thisFrame, nv, flags));
+        } else if(types.isObject(thisFrame)) {
+          matchThis = nodeValues.length > 0;
+        } else {
+          matchThis = false;
         }
       }
     }


### PR DESCRIPTION
This fixes #300 to match behavior in RDF Distiller.

> Expected Behaviour: Given a document with 2 persons "Jane" and "John" and a frame for "givenName": "John" I expect the result to contain only John, but not Jane.

> Actual Behaviour: The result contains both persons, just that Janes givenName is set to null

This moves the initial check on the node to see if it has any properties so that value matches can be checked.

I added a test based on the issue.

(Originally opened #373 but spotted an issue after checking the test-suites -- Now all tests are passing locally.)