### PR TITLE
Default frame for lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Better support for graph framing.
 - Better frame validation.
 - Wildcard matching on `@id` and other `requireAll` semantics.
+- Default frame for lists.
 
 ### Changed
 - Keep term definitions mapping to null so they may be protected.

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -234,9 +234,9 @@ api.frame = (state, subjects, frame, parent, property = null) => {
 
         // recurse into list
         if(graphTypes.isList(o)) {
-          const subframe = (frame[prop] && types.isObject(frame[prop][0]) ?
-            (frame[prop][0]['@list'] || _createImplicitFrame(flags)) :
-            _createImplicitFrame(flags));
+          const subframe = (frame[prop] && frame[prop][0] && frame[prop][0]['@list']) ?
+            frame[prop][0]['@list'] :
+            _createImplicitFrame(flags);
 
           // add empty list
           const list = {'@list': []};

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -235,7 +235,8 @@ api.frame = (state, subjects, frame, parent, property = null) => {
         // recurse into list
         if(graphTypes.isList(o)) {
           const subframe = (frame[prop] && types.isObject(frame[prop][0]) ?
-            frame[prop][0]['@list'] : _createImplicitFrame(flags));
+            (frame[prop][0]['@list'] || _createImplicitFrame(flags)) :
+            _createImplicitFrame(flags));
 
           // add empty list
           const list = {'@list': []};

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -127,7 +127,6 @@ const TEST_TYPES = {
       // FIXME
       idRegex: [
         // lists
-        /frame-manifest.jsonld#t0055$/,
         /frame-manifest.jsonld#t0058$/,
         // included
         /frame-manifest.jsonld#tin01$/,


### PR DESCRIPTION
The code previously would get an invalid frame, if there was a frame object, but it didn't have an `@list` entry.