### PR TITLE
Remove framing `graphStack` code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   - `pruneBlankNodeIdentifiers` based on processingMode.
   - `omitGraph` based on processingMode.
 - Replaced `removePreserve` with `cleanupPreserve` and `cleanupNulls`.
+- Remove unused framing `graphStack` code that was removed from the spec.
 
 ### Added
 - Support for `"@import"`.

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -33,7 +33,6 @@ api.frameMergedOrDefault = (input, frame, options) => {
     embedded: false,
     graph: '@default',
     graphMap: {'@default': {}},
-    graphStack: [],
     subjectStack: [],
     link: {},
     bnodeMap: {}
@@ -188,12 +187,10 @@ api.frame = (state, subjects, frame, parent, property = null) => {
       }
 
       if(recurse) {
-        state.graphStack.push(state.graph);
         // recurse into graph
         api.frame(
           {...state, graph: id, embedded: false},
           Object.keys(state.graphMap[id]).sort(), [subframe], output, '@graph');
-        state.graphStack.pop();
       }
     }
 


### PR DESCRIPTION
- Code was unused and has been removed from the framing spec.