### PR TITLE
Fix for Merge Node Maps algorithm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # jsonld ChangeLog
 
+### Fixed
+- Exclude `@type` from added values in Merge Node Maps step 2.2.1.
+
 ## 3.0.0 - 2020-03-10
 
 ### Notes

--- a/lib/nodeMap.js
+++ b/lib/nodeMap.js
@@ -241,7 +241,7 @@ api.mergeNodeMapGraphs = graphs => {
       const mergedNode = merged[id];
 
       for(const property of Object.keys(node).sort()) {
-        if(isKeyword(property)) {
+        if(isKeyword(property) && property !== '@type') {
           // copy keywords
           mergedNode[property] = util.clone(node[property]);
         } else {


### PR DESCRIPTION
- Exclude `@type` from added values in Merge Node Maps step 2.2.1.
- Fix for https://github.com/w3c/json-ld-api/issues/407.

@gkellogg Please check.  This was a quick guess where the code matches the updated algorithm step.