### PR TITLE
Remove BOM character from context if there is one

### DIFF
--- a/lib/ContextResolver.js
+++ b/lib/ContextResolver.js
@@ -153,6 +153,9 @@ module.exports = class ContextResolver {
       context = remoteDoc.document || null;
       // parse string context as JSON
       if(_isString(context)) {
+        if (context.charCodeAt(0) === 0xFEFF) {
+          context = context.slice(1);
+        }
         context = JSON.parse(context);
       }
     } catch(e) {


### PR DESCRIPTION
Indirectly related to #358. When the context file contains a BOM character, there's an error: 

    cause: SyntaxError: Unexpected token ﻿ in JSON at position 0
        at JSON.parse (<anonymous>)
        at ContextResolver._fetchContext (.../jsonld.js/lib/ContextResolver.js:159:24)

This PR fixes it. 