### PR TITLE
Fixed `prependBase` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fixed
 - Support recusrive scoped contexts.
 - Various EARL report updates.
+- Fixed `prependBase` to start path with a '/' for a zero length path
+  if there is an authority in base.
 
 ### Changed
 - Better support for using a processed context for `null` and caching

--- a/lib/url.js
+++ b/lib/url.js
@@ -107,7 +107,7 @@ api.prependBase = (base, iri) => {
 
         // append relative path to the end of the last directory from base
         path = path.substr(0, path.lastIndexOf('/') + 1);
-        if(path.length > 0 && path.substr(-1) !== '/') {
+        if((path.length > 0 || base.authority) && path.substr(-1) !== '/') {
           path += '/';
         }
         path += rel.path;

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -59,9 +59,6 @@ const TEST_TYPES = {
       // NOTE: idRegex format:
       //MMM-manifest#tNNN$/,
       idRegex: [
-        // IRI resolution (PR #384)
-        /expand-manifest#t0129$/,
-
         // html
         /html-manifest#te001$/,
         /html-manifest#te002$/,
@@ -182,9 +179,6 @@ const TEST_TYPES = {
       // NOTE: idRegex format:
       //MMM-manifest#tNNN$/,
       idRegex: [
-        // IRI resolution (PR #384)
-        /toRdf-manifest#te129$/,
-
         // well formed
         /toRdf-manifest#twf05$/,
 


### PR DESCRIPTION
to start path with a '/' for a zero length path if there is an authority in base.

For expand#t0129 and toRdf#te129.