### PR TITLE
Don't set `@base` in initial context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Changed
 - Better support for using a processed context for `null` and caching
   `@import`.
+- Don't set `@base` in initial context and don't resolve a relative IRI
+  when setting `@base` in a context, so that the document location can
+  be kept separate from the context itself.
 
 ## 3.0.1 - 2020-03-10
 

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -29,7 +29,8 @@ const {
 } = require('./context');
 
 const {
-  removeBase: _removeBase
+  removeBase: _removeBase,
+  prependBase: _prependBase
 } = require('./url');
 
 const {
@@ -226,7 +227,8 @@ api.compact = async ({
           expandedIri => api.compactIri({
             activeCtx,
             iri: expandedIri,
-            relativeTo: {vocab: false}
+            relativeTo: {vocab: false},
+            base: options.base
           }));
         if(compactedValue.length === 1) {
           compactedValue = compactedValue[0];
@@ -485,7 +487,8 @@ api.compact = async ({
             // index on @id or @index or alias of @none
             const key = (container.includes('@id') ?
               expandedItem['@id'] : expandedItem['@index']) ||
-              api.compactIri({activeCtx, iri: '@none', vocab: true});
+              api.compactIri({activeCtx, iri: '@none',
+                relativeTo: {vocab: true}});
             // add compactedItem to map, using value of `@id` or a new blank
             // node identifier
 
@@ -570,7 +573,7 @@ api.compact = async ({
             const indexKey = _getContextValue(
               activeCtx, itemActiveProperty, '@index') || '@index';
             const containerKey = api.compactIri(
-              {activeCtx, iri: indexKey, vocab: true});
+              {activeCtx, iri: indexKey, relativeTo: {vocab: true}});
             if(indexKey === '@index') {
               key = expandedItem['@index'];
               delete compactedItem[containerKey];
@@ -595,14 +598,15 @@ api.compact = async ({
               }
             }
           } else if(container.includes('@id')) {
-            const idKey = api.compactIri({activeCtx, iri: '@id', vocab: true});
+            const idKey = api.compactIri({activeCtx, iri: '@id',
+              relativeTo: {vocab: true}});
             key = compactedItem[idKey];
             delete compactedItem[idKey];
           } else if(container.includes('@type')) {
             const typeKey = api.compactIri({
               activeCtx,
               iri: '@type',
-              vocab: true
+              relativeTo: {vocab: true}
             });
             let types;
             [key, ...types] = _asArray(compactedItem[typeKey] || []);
@@ -634,7 +638,8 @@ api.compact = async ({
 
           // if compacting this value which has no key, index on @none
           if(!key) {
-            key = api.compactIri({activeCtx, iri: '@none', vocab: true});
+            key = api.compactIri({activeCtx, iri: '@none',
+              relativeTo: {vocab: true}});
           }
           // add compact value to map object using key from expanded value
           // based on the container type
@@ -676,6 +681,7 @@ api.compact = async ({
  * @param relativeTo options for how to compact IRIs:
  *          vocab: true to split after @vocab, false not to.
  * @param reverse true if a reverse property is being compacted, false if not.
+ * @param base the absolute URL to use for compacting document-relative IRIs.
  *
  * @return the compacted term, prefix, keyword alias, or the original IRI.
  */
@@ -684,7 +690,8 @@ api.compactIri = ({
   iri,
   value = null,
   relativeTo = {vocab: false},
-  reverse = false
+  reverse = false,
+  base = null
 }) => {
   // can't compact null
   if(iri === null) {
@@ -933,7 +940,16 @@ api.compactIri = ({
 
   // compact IRI relative to base
   if(!relativeTo.vocab) {
-    return _removeBase(activeCtx['@base'], iri);
+    if('@base' in activeCtx) {
+      if(!activeCtx['@base']) {
+        // The None case preserves rval as potentially relative
+        return iri;
+      } else {
+        return _removeBase(_prependBase(base, activeCtx['@base']), iri);
+      }
+    } else {
+      return _removeBase(base, iri);
+    }
   }
 
   // return IRI as is
@@ -1050,8 +1066,11 @@ api.compactValue = ({activeCtx, activeProperty, value, options}) => {
   const expandedProperty = _expandIri(activeCtx, activeProperty, {vocab: true},
     options);
   const type = _getContextValue(activeCtx, activeProperty, '@type');
-  const compacted = api.compactIri(
-    {activeCtx, iri: value['@id'], relativeTo: {vocab: type === '@vocab'}});
+  const compacted = api.compactIri({
+    activeCtx,
+    iri: value['@id'],
+    relativeTo: {vocab: type === '@vocab'},
+    base: options.base});
 
   // compact to scalar
   if(type === '@id' || type === '@vocab' || expandedProperty === '@graph') {

--- a/lib/context.js
+++ b/lib/context.js
@@ -201,12 +201,10 @@ api.process = async ({
     if('@base' in ctx) {
       let base = ctx['@base'];
 
-      if(base === null) {
+      if(base === null || _isAbsoluteIri(base)) {
         // no action
-      } else if(_isAbsoluteIri(base)) {
-        base = parseUrl(base);
       } else if(_isRelativeIri(base)) {
-        base = parseUrl(prependBase(rval['@base'].href, base));
+        base = prependBase(rval['@base'], base);
       } else {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; the value of "@base" in a ' +
@@ -341,7 +339,8 @@ api.process = async ({
         const importCtx = resolvedImport[0].document;
         if('@import' in importCtx) {
           throw new JsonLdError(
-            'Invalid JSON-LD syntax; imported context must not include @import.',
+            'Invalid JSON-LD syntax: ' +
+            'imported context must not include @import.',
             'jsonld.SyntaxError',
             {code: 'invalid context entry', context: localCtx});
         }
@@ -1048,8 +1047,13 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
   }
 
   // prepend base
-  if(relativeTo.base) {
-    return prependBase(activeCtx['@base'], value);
+  if(relativeTo.base && '@base' in activeCtx) {
+    if(activeCtx['@base']) {
+      // The null case preserves value as potentially relative
+      return prependBase(prependBase(options.base, activeCtx['@base']), value);
+    }
+  } else if(relativeTo.base) {
+    return prependBase(options.base, value);
   }
 
   return value;
@@ -1064,15 +1068,13 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
  * @return the initial context.
  */
 api.getInitialContext = options => {
-  const base = parseUrl(options.base || '');
-  const key = JSON.stringify({base, processingMode: options.processingMode});
+  const key = JSON.stringify({processingMode: options.processingMode});
   const cached = INITIAL_CONTEXT_CACHE.get(key);
   if(cached) {
     return cached;
   }
 
   const initialContext = {
-    '@base': base,
     processingMode: options.processingMode,
     mappings: new Map(),
     inverse: null,
@@ -1278,7 +1280,6 @@ api.getInitialContext = options => {
    */
   function _cloneActiveContext() {
     const child = {};
-    child['@base'] = this['@base'];
     child.mappings = util.clone(this.mappings);
     child.clone = this.clone;
     child.inverse = null;
@@ -1288,6 +1289,9 @@ api.getInitialContext = options => {
       child.previousContext = this.previousContext.clone();
     }
     child.revertToPreviousContext = this.revertToPreviousContext;
+    if('@base' in this) {
+      child['@base'] = this['@base'];
+    }
     if('@language' in this) {
       child['@language'] = this['@language'];
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -71,7 +71,7 @@ api.prependBase = (base, iri) => {
   }
 
   // parse base if it is a string
-  if(types.isString(base)) {
+  if(!base || types.isString(base)) {
     base = api.parse(base || '');
   }
 
@@ -158,7 +158,7 @@ api.removeBase = (base, iri) => {
     return iri;
   }
 
-  if(types.isString(base)) {
+  if(!base || types.isString(base)) {
     base = api.parse(base || '');
   }
 


### PR DESCRIPTION
 and don't resolve a relative IRI when setting `@base` in a context, so that the document location can be kept separate from the context itself.

This makes the initial context the same for all processingModes, allowing much more cachability of remote and resolved contexts.