### PR TITLE
Use package.json version field for EARL reports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Don't set `@base` in initial context and don't resolve a relative IRI
   when setting `@base` in a context, so that the document location can
   be kept separate from the context itself.
+- Use `package.json` `version` field for EARL reports.
 
 ## 3.0.1 - 2020-03-10
 

--- a/tests/earl-report.js
+++ b/tests/earl-report.js
@@ -70,12 +70,12 @@ function EarlReport(options) {
     'subjectOf': []
   };
   /* eslint-enable quote-props */
-  // FIXME: read this from somewhere
-  version = 'v3.0.1'
+  const version = require('../package.json').version;
   this._report['@id'] += '#' + this.id;
   this._report['doap:name'] += ' ' + this.id;
   this._report['dc:title'] += ' ' + this.id;
-  this._report['doap:release']['doap:name'] = this._report['doap:name'] + ' ' + version;
+  this._report['doap:release']['doap:name'] =
+    this._report['doap:name'] + ' ' + version;
   this._report['doap:release']['doap:revision'] = version;
 }
 


### PR DESCRIPTION
- This worked with node and karma.
- Is the 'v' prefix important?
- Our versioning setup uses "3.0.2-0" for dev versions, so when creating real reports would want to checkout a released tag like v3.0.x first. (Or fake it by editing package.json)