### PR TITLE
Adds preserve order logic for fromRdf and test case

### DIFF
--- a/lib/fromRdf.js
+++ b/lib/fromRdf.js
@@ -47,7 +47,8 @@ api.fromRDF = async (
   {
     useRdfType = false,
     useNativeTypes = false,
-    rdfDirection = null
+    rdfDirection = null,
+    preserveOrder = false,
   }
 ) => {
   const defaultGraph = {};
@@ -246,13 +247,13 @@ api.fromRDF = async (
   }
 
   const result = [];
-  const subjects = Object.keys(defaultGraph).sort();
+  const subjects = preserveOrder ? Object.keys(defaultGraph): Object.keys(defaultGraph).sort();
   for(const subject of subjects) {
     const node = defaultGraph[subject];
     if(subject in graphMap) {
       const graph = node['@graph'] = [];
       const graphObject = graphMap[subject];
-      const graphSubjects = Object.keys(graphObject).sort();
+      const graphSubjects = preserveOrder ? Object.keys(graphObject) : Object.keys(graphObject).sort();
       for(const graphSubject of graphSubjects) {
         const node = graphObject[graphSubject];
         // only add full subjects to top-level

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -159,6 +159,80 @@ describe('other toRDF tests', () => {
       done();
     });
   });
+  it('should preserve object and property order when specified', done => {
+    const nq = `
+      <http://example.com/Subject3/Property3> <http://example.com/value> "3" <http://example.com/Subject3> .\n
+      <http://example.com/Subject3/Property1> <http://example.com/value> "1" <http://example.com/Subject3> .\n
+      <http://example.com/Subject3/Property2> <http://example.com/value> "2" <http://example.com/Subject3> .\n
+
+      <http://example.com/Subject1/Property3> <http://example.com/value> "3" <http://example.com/Subject1> .\n
+      <http://example.com/Subject1/Property1> <http://example.com/value> "1" <http://example.com/Subject1> .\n
+      <http://example.com/Subject1/Property2> <http://example.com/value> "2" <http://example.com/Subject1> .\n
+
+      <http://example.com/Subject2/Property3> <http://example.com/value> "3" <http://example.com/Subject2> .\n
+      <http://example.com/Subject2/Property1> <http://example.com/value> "1" <http://example.com/Subject2> .\n
+      <http://example.com/Subject2/Property2> <http://example.com/value> "2" <http://example.com/Subject2> .\n
+    `;
+    const p = jsonld.fromRDF(nq, {preserveOrder: true});
+    assert(p instanceof Promise);
+    p.catch(e => {
+      assert.ifError(e);
+    }).then(output => {
+      assert.deepEqual(
+        output,
+        [
+          {"@id": "http://example.com/Subject3",
+          "@graph": [
+            {
+            "@id": "http://example.com/Subject3/Property3",
+            "http://example.com/value": [{"@value": "3"}]
+            },
+            {
+              "@id": "http://example.com/Subject3/Property1",
+              "http://example.com/value": [{"@value": "1"}]
+            },
+            {
+              "@id": "http://example.com/Subject3/Property2",
+              "http://example.com/value": [{"@value": "2"}]
+            }
+          ]
+        },
+        {"@id": "http://example.com/Subject1",
+          "@graph": [
+            {
+            "@id": "http://example.com/Subject1/Property3",
+            "http://example.com/value": [{"@value": "3"}]
+            },
+            {
+              "@id": "http://example.com/Subject1/Property1",
+              "http://example.com/value": [{"@value": "1"}]
+            },
+            {
+              "@id": "http://example.com/Subject1/Property2",
+              "http://example.com/value": [{"@value": "2"}]
+            }
+          ]
+        },
+        {"@id": "http://example.com/Subject2",
+          "@graph": [
+            {
+            "@id": "http://example.com/Subject2/Property3",
+            "http://example.com/value": [{"@value": "3"}]
+            },
+            {
+              "@id": "http://example.com/Subject2/Property1",
+              "http://example.com/value": [{"@value": "1"}]
+            },
+            {
+              "@id": "http://example.com/Subject2/Property2",
+              "http://example.com/value": [{"@value": "2"}]
+            }
+          ]
+        }
+      ]);
+      done();
+    });
+  });
 });
 
 describe('other fromRDF tests', () => {


### PR DESCRIPTION
### For issue 395 (Preserving order of parent nodes and property nodes)

I was previously working with a team that needed to preserve the order of parent and child nodes when created from RDF.

For example, given the quads below, we'd want to control whether subjects 1, 2, and 3 get sorted, and whether their children (properties 1, 2, and 3) are sorted. As of now, `fromRdf` will always sort the parent nodes and children (`Subject 1`, `Properties 1,2,3`; `Subject 2`, `Properties 1,2,3` etc...), losing the original order:

```
<http://example.com/Subject3/Property3> <http://example.com/value> "3" <http://example.com/Subject3> .
<http://example.com/Subject3/Property1> <http://example.com/value> "1" <http://example.com/Subject3> .
<http://example.com/Subject3/Property2> <http://example.com/value> "2" <http://example.com/Subject3> .

<http://example.com/Subject1/Property3> <http://example.com/value> "3" <http://example.com/Subject1> .
<http://example.com/Subject1/Property1> <http://example.com/value> "1" <http://example.com/Subject1> .
<http://example.com/Subject1/Property2> <http://example.com/value> "2" <http://example.com/Subject1> .

<http://example.com/Subject2/Property3> <http://example.com/value> "3" <http://example.com/Subject2> .
<http://example.com/Subject2/Property1> <http://example.com/value> "1" <http://example.com/Subject2> .
<http://example.com/Subject2/Property2> <http://example.com/value> "2" <http://example.com/Subject2> .
```

The codebase was .NET, so the team was using the [linked-data-dotnet/json-ld.net](https://github.com/linked-data-dotnet/json-ld.net) package. Ultimately, we forked our changes from that package, but I'd like to merge those changes into both the .NET library and the node library.
