### PR TITLE
fix(#394): Clone active context to prevent mutation

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -394,7 +394,7 @@ api.process = async ({
         if(process) {
           try {
             await api.process({
-              activeCtx: rval,
+              activeCtx: rval.clone(),
               localCtx: ctx[key]['@context'],
               overrideProtected: true,
               options,


### PR DESCRIPTION
Fixes issue #394 

Change was tested against the w3c test suite and seems to fix the issue.