### PR TITLE
fix: states which protected term is being redefined

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -922,7 +922,7 @@ api.createTermDefinition = ({
       const protectedMode = (options && options.protectedMode) || 'error';
       if(protectedMode === 'error') {
         throw new JsonLdError(
-          'Invalid JSON-LD syntax; tried to redefine a protected term.',
+          `Invalid JSON-LD syntax; tried to redefine ${term} which is a protected term.`,
           'jsonld.SyntaxError',
           {code: 'protected term redefinition', context: localCtx, term});
       } else if(protectedMode === 'warn') {

--- a/lib/context.js
+++ b/lib/context.js
@@ -922,7 +922,7 @@ api.createTermDefinition = ({
       const protectedMode = (options && options.protectedMode) || 'error';
       if(protectedMode === 'error') {
         throw new JsonLdError(
-          `Invalid JSON-LD syntax; tried to redefine ${term} which is a protected term.`,
+          `Invalid JSON-LD syntax; tried to redefine "${term}" which is a protected term.`,
           'jsonld.SyntaxError',
           {code: 'protected term redefinition', context: localCtx, term});
       } else if(protectedMode === 'warn') {


### PR DESCRIPTION
I've been fighting this error blindly for too long. It's time we shed some light on which terms are causing conflicts when protected.