### PR TITLE
Use relative `browser` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     ]
   },
   "browser": {
-    "lib/index.js": "./lib/jsonld.js",
+    "./lib/index.js": "./lib/jsonld.js",
     "crypto": false,
     "http": false,
     "jsonld-request": false,


### PR DESCRIPTION
The browser entries should be relative when replacing files within the current package, otherwise it assumes that you're trying to change a module that doesn't exist and uses the node.js version anyway.

Browser field spec: https://github.com/defunctzombie/package-browser-field-spec. This should fix bundling for browsers, currently I get stuck when resolving `core-js`.