### PR TITLE
Remove manually defining browser global for export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # jsonld ChangeLog
 
+## 6.0.0 -
+
+### Changed
+- **BREAKING**: No longer manually define browser global `JsonLdProcessor`;
+  this is left to Webpack and other bundlers. (Currently, this is messing up
+  downstream bundling and karma tests.)
+
 ## 5.0.0 - 2021-03-18
 
 ### Notes

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -1005,16 +1005,6 @@ jsonld.RequestQueue = require('./RequestQueue');
 /* WebIDL API */
 jsonld.JsonLdProcessor = require('./JsonLdProcessor')(jsonld);
 
-// setup browser global JsonLdProcessor
-if(_browser && typeof global.JsonLdProcessor === 'undefined') {
-  Object.defineProperty(global, 'JsonLdProcessor', {
-    writable: true,
-    enumerable: false,
-    configurable: true,
-    value: jsonld.JsonLdProcessor
-  });
-}
-
 // set platform-specific defaults/APIs
 if(_nodejs) {
   // use node document loader by default

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -82,8 +82,6 @@ const {
 // determine if in-browser or using Node.js
 const _nodejs = (
   typeof process !== 'undefined' && process.versions && process.versions.node);
-const _browser = !_nodejs &&
-  (typeof window !== 'undefined' || typeof self !== 'undefined');
 
 /* eslint-disable indent */
 // attaches jsonld API to the given object


### PR DESCRIPTION
Removes `global` usage (this is messing up downstream webpack and karma usage), no longer manually define the `JsonLdProcessor` global for browsers (this is left for bundlers to do).

Also fixes issue https://github.com/digitalbazaar/jsonld.js/issues/267, and the problem PR https://github.com/digitalbazaar/jsonld.js/pull/311 is trying to address.