### PR TITLE
Use globalThis and split out platform support.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
   env: {
     browser: true,
     commonjs: true,
-    node: true
+    node: true,
+    es2020: true
   },
   extends: 'eslint-config-digitalbazaar',
   root: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonld ChangeLog
 
+### Changed
+- Use `globalThis` to set globals in browser contexts.
+- Split platform support out into Node.js and browser files.
+
 ## 5.0.0 - 2021-03-18
 
 ### Notes

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -34,6 +34,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 const canonize = require('rdf-canonize');
+const platform = require('./platform');
 const util = require('./util');
 const ContextResolver = require('./ContextResolver');
 const IdentifierIssuer = util.IdentifierIssuer;
@@ -78,12 +79,6 @@ const {
   createMergedNodeMap: _createMergedNodeMap,
   mergeNodeMaps: _mergeNodeMaps
 } = require('./nodeMap');
-
-// determine if in-browser or using Node.js
-const _nodejs = (
-  typeof process !== 'undefined' && process.versions && process.versions.node);
-const _browser = !_nodejs &&
-  (typeof window !== 'undefined' || typeof self !== 'undefined');
 
 /* eslint-disable indent */
 // attaches jsonld API to the given object
@@ -938,8 +933,6 @@ jsonld.getContextValue = require('./context').getContextValue;
  * Document loaders.
  */
 jsonld.documentLoaders = {};
-jsonld.documentLoaders.node = require('./documentLoaders/node');
-jsonld.documentLoaders.xhr = require('./documentLoaders/xhr');
 
 /**
  * Assigns the default document loader for external document URLs to a built-in
@@ -1005,24 +998,8 @@ jsonld.RequestQueue = require('./RequestQueue');
 /* WebIDL API */
 jsonld.JsonLdProcessor = require('./JsonLdProcessor')(jsonld);
 
-// setup browser global JsonLdProcessor
-if(_browser && typeof global.JsonLdProcessor === 'undefined') {
-  Object.defineProperty(global, 'JsonLdProcessor', {
-    writable: true,
-    enumerable: false,
-    configurable: true,
-    value: jsonld.JsonLdProcessor
-  });
-}
-
-// set platform-specific defaults/APIs
-if(_nodejs) {
-  // use node document loader by default
-  jsonld.useDocumentLoader('node');
-} else if(typeof XMLHttpRequest !== 'undefined') {
-  // use xhr document loader by default
-  jsonld.useDocumentLoader('xhr');
-}
+platform.setupGlobals(jsonld);
+platform.setupDocumentLoaders(jsonld);
 
 function _setDefaults(options, {
   documentLoader = jsonld.documentLoader,

--- a/lib/platform-browser.js
+++ b/lib/platform-browser.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const xhrLoader = require('./documentLoaders/xhr');
+
+const api = {};
+module.exports = api;
+
+/**
+ * Setup browser document loaders.
+ *
+ * @param jsonld the jsonld api.
+ */
+api.setupDocumentLoaders = function(jsonld) {
+  if(typeof XMLHttpRequest !== 'undefined') {
+    jsonld.documentLoaders.xhr = xhrLoader;
+    // use xhr document loader by default
+    jsonld.useDocumentLoader('xhr');
+  }
+};
+
+/**
+ * Setup browser globals.
+ *
+ * @param jsonld the jsonld api.
+ */
+api.setupGlobals = function(jsonld) {
+  // setup browser global JsonLdProcessor
+  if(typeof globalThis.JsonLdProcessor === 'undefined') {
+    Object.defineProperty(globalThis, 'JsonLdProcessor', {
+      writable: true,
+      enumerable: false,
+      configurable: true,
+      value: jsonld.JsonLdProcessor
+    });
+  }
+};

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const nodeLoader = require('./documentLoaders/node');
+
+const api = {};
+module.exports = api;
+
+/**
+ * Setup Node.js document loaders.
+ *
+ * @param jsonld the jsonld api.
+ */
+api.setupDocumentLoaders = function(jsonld) {
+  jsonld.documentLoaders.node = nodeLoader;
+  // use node document loader by default
+  jsonld.useDocumentLoader('node');
+};
+
+/**
+ * Setup Node.js globals.
+ *
+ * @param jsonld the jsonld api.
+ */
+/* eslint-disable-next-line no-unused-vars */
+api.setupGlobals = function(jsonld) {
+  // none for Node.js
+};

--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
     ]
   },
   "browser": {
-    "lib/index.js": "./lib/jsonld.js",
-    "lib/documentLoaders/node.js": false,
+    "./lib/index.js": "./lib/jsonld.js",
+    "./lib/platform.js": "./lib/platform-browser.js",
     "crypto": false,
     "http": false,
     "jsonld-request": false,


### PR DESCRIPTION
- Use `globalThis` to set globals in browser contexts.
- Split platform support out into Node.js and browser files.

Alternate approach to https://github.com/digitalbazaar/jsonld.js/pull/445.