### PR TITLE
Expand expansion map to support calling when a relative IRI is detected

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1043,11 +1043,11 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
 
   // prepend vocab
   if(relativeTo.vocab && '@vocab' in activeCtx) {
-    return activeCtx['@vocab'] + value;
+    value = activeCtx['@vocab'] + value;
   }
 
   // prepend base
-  if(relativeTo.base && '@base' in activeCtx) {
+  else if(relativeTo.base && '@base' in activeCtx) {
     if(activeCtx['@base']) {
       // The null case preserves value as potentially relative
       value = prependBase(prependBase(options.base, activeCtx['@base']), value);
@@ -1061,6 +1061,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     const expandedResult = options.expansionMap({
       relativeIri: value,
       activeCtx,
+      options
     });
     if(expandedResult !== undefined) {
       value = expandedResult;

--- a/lib/context.js
+++ b/lib/context.js
@@ -1041,6 +1041,14 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     }
   }
 
+  // A flag that captures whether the iri being expanded is
+  // the value for an @type
+  let typeExpansion = false;
+
+  if (options !== undefined && options.typeExpansion !== undefined) {
+    typeExpansion = options.typeExpansion;
+  }
+
   if(relativeTo.vocab && '@vocab' in activeCtx) {
     // prepend vocab
     const prependedResult = activeCtx['@vocab'] + value;
@@ -1056,7 +1064,8 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
           type: '@vocab',
           vocab: activeCtx['@vocab'],
           value,
-          result: prependedResult
+          result: prependedResult,
+          typeExpansion,
         },
         activeCtx,
         options
@@ -1078,6 +1087,9 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
       if(activeCtx['@base']) {
         base = prependBase(options.base, activeCtx['@base']);
         prependedResult = prependBase(base, value);
+      } else {
+        base = activeCtx['@base'];
+        prependedResult = value;
       }
     } else {
       base = options.base;
@@ -1094,7 +1106,8 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
           type: '@base',
           base,
           value,
-          result: prependedResult
+          result: prependedResult,
+          typeExpansion,
         },
         activeCtx,
         options
@@ -1102,7 +1115,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     }
     if(expansionMapResult !== undefined) {
       value = expansionMapResult;
-    } else if(prependedResult !== undefined) {
+    } else {
       // the null case preserves value as potentially relative
       value = prependedResult;
     }
@@ -1118,6 +1131,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     const expandedResult = options.expansionMap({
       relativeIri: value,
       activeCtx,
+      typeExpansion,
       options
     });
     if(expandedResult !== undefined) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -1041,13 +1041,11 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     }
   }
 
-  // prepend vocab
   if(relativeTo.vocab && '@vocab' in activeCtx) {
+    // prepend vocab
     value = activeCtx['@vocab'] + value;
-  }
-
-  // prepend base
-  else if(relativeTo.base && '@base' in activeCtx) {
+  } else if(relativeTo.base && '@base' in activeCtx) {
+    // prepend base
     if(activeCtx['@base']) {
       // The null case preserves value as potentially relative
       value = prependBase(prependBase(options.base, activeCtx['@base']), value);

--- a/lib/context.js
+++ b/lib/context.js
@@ -1050,7 +1050,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
   if(relativeTo.base && '@base' in activeCtx) {
     if(activeCtx['@base']) {
       // The null case preserves value as potentially relative
-      return prependBase(prependBase(options.base, activeCtx['@base']), value);
+      value = prependBase(prependBase(options.base, activeCtx['@base']), value);
     }
   } else if(relativeTo.base) {
     value = prependBase(options.base, value);

--- a/lib/context.js
+++ b/lib/context.js
@@ -1045,7 +1045,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
   // the value for an @type
   let typeExpansion = false;
 
-  if (options !== undefined && options.typeExpansion !== undefined) {
+  if(options !== undefined && options.typeExpansion !== undefined) {
     typeExpansion = options.typeExpansion;
   }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -1043,18 +1043,96 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
 
   if(relativeTo.vocab && '@vocab' in activeCtx) {
     // prepend vocab
-    value = activeCtx['@vocab'] + value;
+    const prependedResult = activeCtx['@vocab'] + value;
+    let expansionMapResult = undefined;
+    if(options && options.expansionMap) {
+      // if we are about to expand the value by prepending
+      // @vocab then call the expansion map to inform
+      // interested callers that this is occurring
+
+      // TODO: use `await` to support async
+      expansionMapResult = options.expansionMap({
+        prependedIri: {
+          type: '@vocab',
+          vocab: activeCtx['@vocab'],
+          value,
+          result: prependedResult
+        },
+        activeCtx,
+        options
+      });
+
+    }
+    if(expansionMapResult !== undefined) {
+      value = expansionMapResult;
+    } else {
+      // the null case preserves value as potentially relative
+      value = prependedResult;
+    }
   } else if(relativeTo.base && '@base' in activeCtx) {
     // prepend base
     if(activeCtx['@base']) {
-      // The null case preserves value as potentially relative
-      value = prependBase(prependBase(options.base, activeCtx['@base']), value);
+      const prependedResult = prependBase(
+        prependBase(options.base, activeCtx['@base']), value);
+
+      let expansionMapResult = undefined;
+      if(options && options.expansionMap) {
+        // if we are about to expand the value by prepending
+        // @base then call the expansion map to inform
+        // interested callers that this is occurring
+
+        // TODO: use `await` to support async
+        expansionMapResult = options.expansionMap({
+          prependedIri: {
+            type: '@base',
+            base: activeCtx['@base'],
+            value,
+            result: prependedResult
+          },
+          activeCtx,
+          options
+        });
+      }
+      if(expansionMapResult !== undefined) {
+        value = expansionMapResult;
+      } else {
+        // the null case preserves value as potentially relative
+        value = prependedResult;
+      }
     }
   } else if(relativeTo.base) {
-    value = prependBase(options.base, value);
+    const prependedResult = prependBase(options.base, value);
+    let expansionMapResult = undefined;
+    if(options && options.expansionMap) {
+      // if we are about to expand the value by prepending
+      // @base then call the expansion map to inform
+      // interested callers that this is occurring
+
+      // TODO: use `await` to support async
+      expansionMapResult = options.expansionMap({
+        prependedIri: {
+          type: '@base',
+          base: options.base,
+          value,
+          result: prependedResult
+        },
+        activeCtx,
+        options
+      });
+    }
+    if(expansionMapResult !== undefined) {
+      value = expansionMapResult;
+    } else {
+      value = prependedResult;
+    }
   }
 
-  if(!_isAbsoluteIri(value) && options.expansionMap) {
+  if(!_isAbsoluteIri(value) && options && options.expansionMap) {
+    // if the result of the expansion is not an absolute iri then
+    // call the expansion map to inform interested callers that
+    // the resulting value is a relative iri, which can result in
+    // it being dropped when converting to other RDF representations
+
     // TODO: use `await` to support async
     const expandedResult = options.expansionMap({
       relativeIri: value,

--- a/lib/context.js
+++ b/lib/context.js
@@ -1069,42 +1069,22 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
       // the null case preserves value as potentially relative
       value = prependedResult;
     }
-  } else if(relativeTo.base && '@base' in activeCtx) {
-    // prepend base
-    if(activeCtx['@base']) {
-      const prependedResult = prependBase(
-        prependBase(options.base, activeCtx['@base']), value);
-
-      let expansionMapResult = undefined;
-      if(options && options.expansionMap) {
-        // if we are about to expand the value by prepending
-        // @base then call the expansion map to inform
-        // interested callers that this is occurring
-
-        // TODO: use `await` to support async
-        expansionMapResult = options.expansionMap({
-          prependedIri: {
-            type: '@base',
-            base: activeCtx['@base'],
-            value,
-            result: prependedResult
-          },
-          activeCtx,
-          options
-        });
-      }
-      if(expansionMapResult !== undefined) {
-        value = expansionMapResult;
-      } else {
-        // the null case preserves value as potentially relative
-        value = prependedResult;
-      }
-    }
   } else if(relativeTo.base) {
-    const prependedResult = prependBase(options.base, value);
-    let expansionMapResult = undefined;
+    // prepend base
+    let prependedResult;
+    let expansionMapResult;
+    let base;
+    if('@base' in activeCtx) {
+      if(activeCtx['@base']) {
+        base = prependBase(options.base, activeCtx['@base']);
+        prependedResult = prependBase(base, value);
+      }
+    } else {
+      base = options.base;
+      prependedResult = prependBase(options.base, value);
+    }
     if(options && options.expansionMap) {
-      // if we are about to expand the value by prepending
+      // if we are about to expand the value by pre-pending
       // @base then call the expansion map to inform
       // interested callers that this is occurring
 
@@ -1112,7 +1092,7 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
       expansionMapResult = options.expansionMap({
         prependedIri: {
           type: '@base',
-          base: options.base,
+          base,
           value,
           result: prependedResult
         },
@@ -1122,7 +1102,8 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
     }
     if(expansionMapResult !== undefined) {
       value = expansionMapResult;
-    } else {
+    } else if(prependedResult !== undefined) {
+      // the null case preserves value as potentially relative
       value = prependedResult;
     }
   }

--- a/lib/context.js
+++ b/lib/context.js
@@ -1053,7 +1053,18 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined, options) {
       return prependBase(prependBase(options.base, activeCtx['@base']), value);
     }
   } else if(relativeTo.base) {
-    return prependBase(options.base, value);
+    value = prependBase(options.base, value);
+  }
+
+  if(!_isAbsoluteIri(value) && options.expansionMap) {
+    // TODO: use `await` to support async
+    const expandedResult = options.expansionMap({
+      relativeIri: value,
+      activeCtx,
+    });
+    if(expandedResult !== undefined) {
+      value = expandedResult;
+    }
   }
 
   return value;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -528,7 +528,6 @@ async function _expandObject({
         ]));
       }
       _validateTypeValue(value, options.isFrame);
-
       _addValue(
         expandedParent, '@type',
         _asArray(value).map(v =>

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -431,7 +431,7 @@ async function _expandObject({
   const isJsonType = element[typeKey] &&
     _expandIri(activeCtx,
       (_isArray(element[typeKey]) ? element[typeKey][0] : element[typeKey]),
-      {vocab: true}, options) === '@json';
+      {vocab: true}, { ...options, typeExpansion: true }) === '@json';
 
   for(const key of keys) {
     let value = element[key];
@@ -527,7 +527,7 @@ async function _expandObject({
         value = Object.fromEntries(Object.entries(value).map(([k, v]) => [
           _expandIri(typeScopedContext, k, {vocab: true}),
           _asArray(v).map(vv =>
-            _expandIri(typeScopedContext, vv, {base: true, vocab: true})
+            _expandIri(typeScopedContext, vv, {base: true, vocab: true}, { ...options, typeExpansion: true })
           )
         ]));
       }
@@ -537,7 +537,7 @@ async function _expandObject({
         _asArray(value).map(v =>
           _isString(v) ?
             _expandIri(typeScopedContext, v,
-              {base: true, vocab: true}, options) : v),
+              {base: true, vocab: true}, { ...options, typeExpansion: true }) : v),
         {propertyIsArray: options.isFrame});
       continue;
     }
@@ -937,7 +937,7 @@ function _expandValue({activeCtx, activeProperty, value, options}) {
   if(expandedProperty === '@id') {
     return _expandIri(activeCtx, value, {base: true}, options);
   } else if(expandedProperty === '@type') {
-    return _expandIri(activeCtx, value, {vocab: true, base: true}, options);
+    return _expandIri(activeCtx, value, {vocab: true, base: true}, { ...options, typeExpansion: true });
   }
 
   // get type definition from context

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -420,6 +420,9 @@ async function _expandObject({
   const nests = [];
   let unexpandedValue;
 
+  // Add expansion map to the processing options
+  options = {...options, expansionMap};
+
   // Figure out if this is the type for a JSON literal
   const isJsonType = element[typeKey] &&
     _expandIri(activeCtx,

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -77,7 +77,7 @@ api.expand = async ({
 }) => {
 
   // add expansion map to the processing options
-  options = { ...options, expansionMap };
+  options = {...options, expansionMap};
 
   // nothing to expand
   if(element === null || element === undefined) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -76,7 +76,7 @@ api.expand = async ({
   expansionMap = () => undefined
 }) => {
 
-  // Add expansion map to the processing options
+  // add expansion map to the processing options
   options = { ...options, expansionMap };
 
   // nothing to expand

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -431,7 +431,7 @@ async function _expandObject({
   const isJsonType = element[typeKey] &&
     _expandIri(activeCtx,
       (_isArray(element[typeKey]) ? element[typeKey][0] : element[typeKey]),
-      {vocab: true}, { ...options, typeExpansion: true }) === '@json';
+      {vocab: true}, {...options, typeExpansion: true}) === '@json';
 
   for(const key of keys) {
     let value = element[key];
@@ -527,7 +527,8 @@ async function _expandObject({
         value = Object.fromEntries(Object.entries(value).map(([k, v]) => [
           _expandIri(typeScopedContext, k, {vocab: true}),
           _asArray(v).map(vv =>
-            _expandIri(typeScopedContext, vv, {base: true, vocab: true}, { ...options, typeExpansion: true })
+            _expandIri(typeScopedContext, vv, {base: true, vocab: true},
+              {...options, typeExpansion: true})
           )
         ]));
       }
@@ -537,7 +538,8 @@ async function _expandObject({
         _asArray(value).map(v =>
           _isString(v) ?
             _expandIri(typeScopedContext, v,
-              {base: true, vocab: true}, { ...options, typeExpansion: true }) : v),
+              {base: true, vocab: true},
+              {...options, typeExpansion: true}) : v),
         {propertyIsArray: options.isFrame});
       continue;
     }
@@ -937,7 +939,8 @@ function _expandValue({activeCtx, activeProperty, value, options}) {
   if(expandedProperty === '@id') {
     return _expandIri(activeCtx, value, {base: true}, options);
   } else if(expandedProperty === '@type') {
-    return _expandIri(activeCtx, value, {vocab: true, base: true}, { ...options, typeExpansion: true });
+    return _expandIri(activeCtx, value, {vocab: true, base: true},
+      {...options, typeExpansion: true});
   }
 
   // get type definition from context

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -505,10 +505,27 @@ async function _expandObject({
         }
       }
 
+      const expandedValues = _asArray(value).map(v =>
+        _isString(v) ? _expandIri(activeCtx, v, {base: true}, options) : v);
+
+      for(const i in expandedValues) {
+        if(_isString(expandedValues[i]) && !_isAbsoluteIri(expandedValues[i])) {
+          const expansionMapResult = await expansionMap({
+            relativeIri: {type: key, value: expandedValues[i]},
+            activeCtx,
+            activeProperty,
+            options,
+            insideList
+          });
+          if(expansionMapResult !== undefined) {
+            expandedValues[i] = expansionMapResult;
+          }
+        }
+      }
+
       _addValue(
         expandedParent, '@id',
-        _asArray(value).map(v =>
-          _isString(v) ? _expandIri(activeCtx, v, {base: true}, options) : v),
+        expandedValues,
         {propertyIsArray: options.isFrame});
       continue;
     }
@@ -525,12 +542,30 @@ async function _expandObject({
         ]));
       }
       _validateTypeValue(value, options.isFrame);
+
+      const expandedValues = _asArray(value).map(v =>
+        _isString(v) ?
+          _expandIri(typeScopedContext, v,
+            {base: true, vocab: true}, options) : v);
+
+      for(const i in expandedValues) {
+        if(_isString(expandedValues[i]) && !_isAbsoluteIri(expandedValues[i])) {
+          const expansionMapResult = await expansionMap({
+            relativeIri: {type: key, value: expandedValues[i]},
+            activeCtx,
+            activeProperty,
+            options,
+            insideList
+          });
+          if(expansionMapResult !== undefined) {
+            expandedValues[i] = expansionMapResult;
+          }
+        }
+      }
+
       _addValue(
         expandedParent, '@type',
-        _asArray(value).map(v =>
-          _isString(v) ?
-            _expandIri(typeScopedContext, v,
-              {base: true, vocab: true}, options) : v),
+        expandedValues,
         {propertyIsArray: options.isFrame});
       continue;
     }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -75,6 +75,10 @@ api.expand = async ({
   typeScopedContext = null,
   expansionMap = () => undefined
 }) => {
+
+  // Add expansion map to the processing options
+  options = { ...options, expansionMap };
+
   // nothing to expand
   if(element === null || element === undefined) {
     return null;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -508,27 +508,10 @@ async function _expandObject({
         }
       }
 
-      const expandedValues = _asArray(value).map(v =>
-        _isString(v) ? _expandIri(activeCtx, v, {base: true}, options) : v);
-
-      for(const i in expandedValues) {
-        if(_isString(expandedValues[i]) && !_isAbsoluteIri(expandedValues[i])) {
-          const expansionMapResult = await expansionMap({
-            relativeIri: {type: key, value: expandedValues[i]},
-            activeCtx,
-            activeProperty,
-            options,
-            insideList
-          });
-          if(expansionMapResult !== undefined) {
-            expandedValues[i] = expansionMapResult;
-          }
-        }
-      }
-
       _addValue(
         expandedParent, '@id',
-        expandedValues,
+        _asArray(value).map(v =>
+          _isString(v) ? _expandIri(activeCtx, v, {base: true}, options) : v),
         {propertyIsArray: options.isFrame});
       continue;
     }
@@ -546,29 +529,12 @@ async function _expandObject({
       }
       _validateTypeValue(value, options.isFrame);
 
-      const expandedValues = _asArray(value).map(v =>
-        _isString(v) ?
-          _expandIri(typeScopedContext, v,
-            {base: true, vocab: true}, options) : v);
-
-      for(const i in expandedValues) {
-        if(_isString(expandedValues[i]) && !_isAbsoluteIri(expandedValues[i])) {
-          const expansionMapResult = await expansionMap({
-            relativeIri: {type: key, value: expandedValues[i]},
-            activeCtx,
-            activeProperty,
-            options,
-            insideList
-          });
-          if(expansionMapResult !== undefined) {
-            expandedValues[i] = expansionMapResult;
-          }
-        }
-      }
-
       _addValue(
         expandedParent, '@type',
-        expandedValues,
+        _asArray(value).map(v =>
+          _isString(v) ?
+            _expandIri(typeScopedContext, v,
+              {base: true, vocab: true}, options) : v),
         {propertyIsArray: options.isFrame});
       continue;
     }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -424,7 +424,7 @@ async function _expandObject({
   const nests = [];
   let unexpandedValue;
 
-  // Add expansion map to the processing options
+  // add expansion map to the processing options
   options = {...options, expansionMap};
 
   // Figure out if this is the type for a JSON literal

--- a/lib/util.js
+++ b/lib/util.js
@@ -130,7 +130,7 @@ api.parseLinkHeader = header => {
     while((match = REGEX_LINK_HEADER_PARAMS.exec(params))) {
       result[match[1]] = (match[2] === undefined) ? match[3] : match[2];
     }
-    const rel = result['rel'] || '';
+    const rel = result.rel || '';
     if(Array.isArray(rval[rel])) {
       rval[rel].push(result);
     } else if(rval.hasOwnProperty(rel)) {

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -480,264 +480,459 @@ describe('literal JSON', () => {
 });
 
 describe('expansionMap', () => {
-  it('should be called on unmapped term', async () => {
-    const docWithUnMappedTerm = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      definedTerm: "is defined",
-      testUndefined: "is undefined"
-    };
-
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.unmappedProperty === 'testUndefined') {
-        expansionMapCalled = true;
-      }
-    };
-
-    await jsonld.expand(docWithUnMappedTerm, {expansionMap});
-
-    assert.equal(expansionMapCalled, true);
-  });
-
-  it('should be called on nested unmapped term', async () => {
-    const docWithUnMappedTerm = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      definedTerm: {
+  describe('unmappedProperty', () => {
+    it('should be called on unmapped term', async () => {
+      const docWithUnMappedTerm = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        definedTerm: "is defined",
         testUndefined: "is undefined"
-      }
-    };
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.unmappedProperty === 'testUndefined') {
-        expansionMapCalled = true;
-      }
-    };
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.unmappedProperty === 'testUndefined') {
+          expansionMapCalled = true;
+        }
+      };
 
-    await jsonld.expand(docWithUnMappedTerm, {expansionMap});
+      await jsonld.expand(docWithUnMappedTerm, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it('should be called on nested unmapped term', async () => {
+      const docWithUnMappedTerm = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        definedTerm: {
+          testUndefined: "is undefined"
+        }
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.unmappedProperty === 'testUndefined') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithUnMappedTerm, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
   });
 
-  it('should be called on relative iri for id term', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      '@id': "relativeiri",
-      definedTerm: "is defined"
-    };
+  describe('relativeIri', () => {
+    it('should be called on relative iri for id term', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        '@id': "relativeiri",
+        definedTerm: "is defined"
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri') {
-        expansionMapCalled = true;
-      }
-    };
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it('should be called on relative iri for id term (nested)', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        '@id': "urn:absoluteIri",
+        definedTerm: {
+          '@id': "relativeiri"
+        }
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it('should be called on relative iri for aliased id term', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'id': '@id',
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        'id': "relativeiri",
+        definedTerm: "is defined"
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it('should be called on relative iri for type term', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        'id': "urn:absoluteiri",
+        '@type': "relativeiri",
+        definedTerm: "is defined"
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it('should be called on relative iri for \
+    type term with multiple relative iri types', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        'id': "urn:absoluteiri",
+        '@type': ["relativeiri", "anotherRelativeiri" ],
+        definedTerm: "is defined"
+      };
+
+      let expansionMapCalledTimes = 0;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri' ||
+           info.relativeIri === 'anotherRelativeiri') {
+          expansionMapCalledTimes++;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalledTimes, 3);
+    });
+
+    it('should be called on relative iri for \
+    type term with multiple types', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        'id': "urn:absoluteiri",
+        '@type': ["relativeiri", "definedTerm" ],
+        definedTerm: "is defined"
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it('should be called on relative iri for aliased type term', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'type': "@type",
+          'definedTerm': 'https://example.com#definedTerm'
+        },
+        'id': "urn:absoluteiri",
+        'type': "relativeiri",
+        definedTerm: "is defined"
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it("should be called on relative iri when \
+    @base value is './'", async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          "@base": "./",
+        },
+        '@id': "relativeiri",
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === '/relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it("should be called on relative iri when \
+    @base value is './'", async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          "@base": "./",
+        },
+        '@id': "relativeiri",
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === '/relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
+    it("should be called on relative iri when \
+    @vocab value is './'", async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          "@vocab": "./",
+        },
+        '@type': "relativeiri",
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === '/relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
   });
 
-  it('should be called on relative iri for id term (nested)', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      '@id': "urn:absoluteIri",
-      definedTerm: {
-        '@id': "relativeiri"
-      }
-    };
+  describe('prependedIri', () => {
+    it("should be called when property is \
+    being expanded with `@vocab`", async () => {
+      const doc = {
+        '@context': {
+          "@vocab": "http://example.com/",
+        },
+        'term': "termValue",
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri') {
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        assert.deepStrictEqual(info.prependedIri, {
+          type: '@vocab',
+          vocab: 'http://example.com/',
+          value: 'term',
+          result: 'http://example.com/term'
+        });
         expansionMapCalled = true;
-      }
-    };
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
-  });
+      assert.equal(expansionMapCalled, true);
+    });
 
-  it('should be called on relative iri for aliased id term', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'id': '@id',
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      'id': "relativeiri",
-      definedTerm: "is defined"
-    };
+    it("should be called when '@type' is \
+    being expanded with `@vocab`", async () => {
+      const doc = {
+        '@context': {
+          "@vocab": "http://example.com/",
+        },
+        '@type': "relativeIri",
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri') {
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        assert.deepStrictEqual(info.prependedIri, {
+          type: '@vocab',
+          vocab: 'http://example.com/',
+          value: 'relativeIri',
+          result: 'http://example.com/relativeIri'
+        });
         expansionMapCalled = true;
-      }
-    };
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
-  });
+      assert.equal(expansionMapCalled, true);
+    });
 
-  it('should be called on relative iri for type term', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      'id': "urn:absoluteiri",
-      '@type': "relativeiri",
-      definedTerm: "is defined"
-    };
+    it("should be called when aliased '@type' is \
+    being expanded with `@vocab`", async () => {
+      const doc = {
+        '@context': {
+          "@vocab": "http://example.com/",
+          "type": "@type"
+        },
+        'type': "relativeIri",
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri') {
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        assert.deepStrictEqual(info.prependedIri, {
+          type: '@vocab',
+          vocab: 'http://example.com/',
+          value: 'relativeIri',
+          result: 'http://example.com/relativeIri'
+        });
         expansionMapCalled = true;
-      }
-    };
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
-  });
+      assert.equal(expansionMapCalled, true);
+    });
 
-  it('should be called on relative iri for \
-  type term with multiple relative iri types', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      'id': "urn:absoluteiri",
-      '@type': ["relativeiri", "anotherRelativeiri" ],
-      definedTerm: "is defined"
-    };
+    it("should be called when '@id' is being \
+    expanded with `@base`", async () => {
+      const doc = {
+        '@context': {
+          "@base": "http://example.com/",
+        },
+        '@id': "relativeIri",
+      };
 
-    let expansionMapCalledTimes = 0;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri' ||
-         info.relativeIri === 'anotherRelativeiri') {
-        expansionMapCalledTimes++;
-      }
-    };
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.prependedIri) {
+          assert.deepStrictEqual(info.prependedIri, {
+            type: '@base',
+            base: 'http://example.com/',
+            value: 'relativeIri',
+            result: 'http://example.com/relativeIri'
+          });
+          expansionMapCalled = true;
+        }
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalledTimes, 3);
-  });
+      assert.equal(expansionMapCalled, true);
+    });
 
-  it('should be called on relative iri for \
-  type term with multiple types', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      'id': "urn:absoluteiri",
-      '@type': ["relativeiri", "definedTerm" ],
-      definedTerm: "is defined"
-    };
+    it("should be called when aliased '@id' \
+    is being expanded with `@base`", async () => {
+      const doc = {
+        '@context': {
+          "@base": "http://example.com/",
+          "id": "@id"
+        },
+        'id': "relativeIri",
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri') {
-        expansionMapCalled = true;
-      }
-    };
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.prependedIri) {
+          assert.deepStrictEqual(info.prependedIri, {
+            type: '@base',
+            base: 'http://example.com/',
+            value: 'relativeIri',
+            result: 'http://example.com/relativeIri'
+          });
+          expansionMapCalled = true;
+        }
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
-  });
+      assert.equal(expansionMapCalled, true);
+    });
 
-  it('should be called on relative iri for aliased type term', async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        'type': "@type",
-        'definedTerm': 'https://example.com#definedTerm'
-      },
-      'id': "urn:absoluteiri",
-      'type': "relativeiri",
-      definedTerm: "is defined"
-    };
+    it("should be called when '@type' is \
+    being expanded with `@base`", async () => {
+      const doc = {
+        '@context': {
+          "@base": "http://example.com/",
+        },
+        '@type': "relativeIri",
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === 'relativeiri') {
-        expansionMapCalled = true;
-      }
-    };
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.prependedIri) {
+          assert.deepStrictEqual(info.prependedIri, {
+            type: '@base',
+            base: 'http://example.com/',
+            value: 'relativeIri',
+            result: 'http://example.com/relativeIri'
+          });
+          expansionMapCalled = true;
+        }
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
-  });
+      assert.equal(expansionMapCalled, true);
+    });
 
-  it("should be called on relative iri when @base value is './'", async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        "@base": "./",
-      },
-      '@id': "relativeiri",
-    };
+    it("should be called when aliased '@type' is \
+    being expanded with `@base`", async () => {
+      const doc = {
+        '@context': {
+          "@base": "http://example.com/",
+          "type": "@type"
+        },
+        'type': "relativeIri",
+      };
 
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === '/relativeiri') {
-        expansionMapCalled = true;
-      }
-    };
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.prependedIri) {
+          assert.deepStrictEqual(info.prependedIri, {
+            type: '@base',
+            base: 'http://example.com/',
+            value: 'relativeIri',
+            result: 'http://example.com/relativeIri'
+          });
+          expansionMapCalled = true;
+        }
+      };
 
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+      await jsonld.expand(doc, {expansionMap});
 
-    assert.equal(expansionMapCalled, true);
-  });
-
-  it("should be called on relative iri when @base value is './'", async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        "@base": "./",
-      },
-      '@id': "relativeiri",
-    };
-
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === '/relativeiri') {
-        expansionMapCalled = true;
-      }
-    };
-
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
-
-    assert.equal(expansionMapCalled, true);
-  });
-
-  it("should be called on relative iri when @vocab value is './'", async () => {
-    const docWithRelativeIriId = {
-      '@context': {
-        "@vocab": "./",
-      },
-      '@type': "relativeiri",
-    };
-
-    let expansionMapCalled = false;
-    const expansionMap = info => {
-      if(info.relativeIri === '/relativeiri') {
-        expansionMapCalled = true;
-      }
-    };
-
-    await jsonld.expand(docWithRelativeIriId, {expansionMap});
-
-    assert.equal(expansionMapCalled, true);
+      assert.equal(expansionMapCalled, true);
+    });
   });
 });

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -480,7 +480,7 @@ describe('literal JSON', () => {
 });
 
 describe('expansionMap', () => {
-  it('should be called on un-mapped term', async () => {
+  it('should be called on unmapped term', async () => {
     const docWithUnMappedTerm = {
       '@context': {
         'definedTerm': 'https://example.com#definedTerm'

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -614,6 +614,36 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
+    it('should be called on relative iri for type term in scoped context', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedType': {
+            '@id': 'https://example.com#definedType',
+            '@context': {
+              'definedTerm': 'https://example.com#definedTerm'
+
+            }
+          }
+        },
+        'id': "urn:absoluteiri",
+        '@type': "definedType",
+        definedTerm: {
+          '@type': 'relativeiri'
+        }
+      };
+
+      let expansionMapCalled = false;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri') {
+          expansionMapCalled = true;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalled, true);
+    });
+
     it('should be called on relative iri for \
     type term with multiple relative iri types', async () => {
       const docWithRelativeIriId = {
@@ -623,6 +653,38 @@ describe('expansionMap', () => {
         'id': "urn:absoluteiri",
         '@type': ["relativeiri", "anotherRelativeiri" ],
         definedTerm: "is defined"
+      };
+
+      let expansionMapCalledTimes = 0;
+      const expansionMap = info => {
+        if(info.relativeIri === 'relativeiri' ||
+           info.relativeIri === 'anotherRelativeiri') {
+          expansionMapCalledTimes++;
+        }
+      };
+
+      await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+      assert.equal(expansionMapCalledTimes, 3);
+    });
+
+    it('should be called on relative iri for \
+    type term with multiple relative iri types in scoped context', async () => {
+      const docWithRelativeIriId = {
+        '@context': {
+          'definedType': {
+            '@id': 'https://example.com#definedType',
+            '@context': {
+              'definedTerm': 'https://example.com#definedTerm'
+
+            }
+          }
+        },
+        'id': "urn:absoluteiri",
+        '@type': "definedType",
+        definedTerm: {
+          '@type': ["relativeiri", "anotherRelativeiri" ]
+        }
       };
 
       let expansionMapCalledTimes = 0;
@@ -764,6 +826,7 @@ describe('expansionMap', () => {
           type: '@vocab',
           vocab: 'http://example.com/',
           value: 'term',
+          typeExpansion: false,
           result: 'http://example.com/term'
         });
         expansionMapCalled = true;
@@ -789,6 +852,7 @@ describe('expansionMap', () => {
           type: '@vocab',
           vocab: 'http://example.com/',
           value: 'relativeIri',
+          typeExpansion: true,
           result: 'http://example.com/relativeIri'
         });
         expansionMapCalled = true;
@@ -815,6 +879,7 @@ describe('expansionMap', () => {
           type: '@vocab',
           vocab: 'http://example.com/',
           value: 'relativeIri',
+          typeExpansion: true,
           result: 'http://example.com/relativeIri'
         });
         expansionMapCalled = true;
@@ -841,6 +906,7 @@ describe('expansionMap', () => {
             type: '@base',
             base: 'http://example.com/',
             value: 'relativeIri',
+            typeExpansion: false,
             result: 'http://example.com/relativeIri'
           });
           expansionMapCalled = true;
@@ -869,6 +935,7 @@ describe('expansionMap', () => {
             type: '@base',
             base: 'http://example.com/',
             value: 'relativeIri',
+            typeExpansion: false,
             result: 'http://example.com/relativeIri'
           });
           expansionMapCalled = true;
@@ -896,6 +963,7 @@ describe('expansionMap', () => {
             type: '@base',
             base: 'http://example.com/',
             value: 'relativeIri',
+            typeExpansion: true,
             result: 'http://example.com/relativeIri'
           });
           expansionMapCalled = true;
@@ -924,6 +992,7 @@ describe('expansionMap', () => {
             type: '@base',
             base: 'http://example.com/',
             value: 'relativeIri',
+            typeExpansion: true,
             result: 'http://example.com/relativeIri'
           });
           expansionMapCalled = true;

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -614,7 +614,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it('should be called on relative iri for type term in scoped context', async () => {
+    it('should be called on relative iri for type\
+     term in scoped context', async () => {
       const docWithRelativeIriId = {
         '@context': {
           'definedType': {

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -478,3 +478,207 @@ describe('literal JSON', () => {
     });
   });
 });
+
+describe('expansionMap', () => {
+  it('should be called on un-mapped term', async () => {
+    const docWithUnMappedTerm = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      definedTerm: "is defined",
+      testUndefined: "is undefined"
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.unmappedProperty === 'testUndefined') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithUnMappedTerm, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on nested un-mapped term', async () => {
+    const docWithUnMappedTerm = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      definedTerm: {
+        testUndefined: "is undefined"
+      }
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.unmappedProperty === 'testUndefined') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithUnMappedTerm, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on relative iri for id term', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      '@id': "relativeiri",
+      definedTerm: "is defined"
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on relative iri for id term (nested)', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      '@id': "urn:absoluteIri",
+      definedTerm: {
+        '@id': "relativeiri"
+      }
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on relative iri for aliased id term', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'id': '@id',
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      'id': "relativeiri",
+      definedTerm: "is defined"
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on relative iri for type term', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      'id': "urn:absoluteiri",
+      '@type': "relativeiri",
+      definedTerm: "is defined"
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on relative iri for \
+  type term with multiple relative iri types', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      'id': "urn:absoluteiri",
+      '@type': ["relativeiri", "anotherRelativeiri" ],
+      definedTerm: "is defined"
+    };
+
+    let expansionMapCalledTimes = 0;
+    const expansionMap = info => {
+      if(info.relativeIri &&
+        (info.relativeIri.value === 'relativeiri' ||
+         info.relativeIri.value === 'anotherRelativeiri')) {
+        expansionMapCalledTimes++;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalledTimes, 2);
+  });
+
+  it('should be called on relative iri for \
+  type term with multiple types', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      'id': "urn:absoluteiri",
+      '@type': ["relativeiri", "definedTerm" ],
+      definedTerm: "is defined"
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it('should be called on relative iri for aliased type term', async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        'type': "@type",
+        'definedTerm': 'https://example.com#definedTerm'
+      },
+      'id': "urn:absoluteiri",
+      'type': "relativeiri",
+      definedTerm: "is defined"
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+});

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -686,12 +686,52 @@ describe('expansionMap', () => {
       '@context': {
         "@base": "./",
       },
-      '@id': "absoluteiri",
+      '@id': "relativeiri",
     };
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri === '/absoluteiri') {
+      if(info.relativeIri === '/relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it("should be called on relative iri when @base value is './'", async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        "@base": "./",
+      },
+      '@id': "relativeiri",
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri === '/relativeiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
+
+  it("should be called on relative iri when @vocab value is './'", async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        "@vocab": "./",
+      },
+      '@type': "relativeiri",
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri === '/relativeiri') {
         expansionMapCalled = true;
       }
     };

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -534,7 +534,7 @@ describe('expansionMap', () => {
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+      if(info.relativeIri === 'relativeiri') {
         expansionMapCalled = true;
       }
     };
@@ -557,7 +557,7 @@ describe('expansionMap', () => {
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+      if(info.relativeIri === 'relativeiri') {
         expansionMapCalled = true;
       }
     };
@@ -579,7 +579,7 @@ describe('expansionMap', () => {
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+      if(info.relativeIri === 'relativeiri') {
         expansionMapCalled = true;
       }
     };
@@ -601,7 +601,7 @@ describe('expansionMap', () => {
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+      if(info.relativeIri === 'relativeiri') {
         expansionMapCalled = true;
       }
     };
@@ -624,16 +624,15 @@ describe('expansionMap', () => {
 
     let expansionMapCalledTimes = 0;
     const expansionMap = info => {
-      if(info.relativeIri &&
-        (info.relativeIri.value === 'relativeiri' ||
-         info.relativeIri.value === 'anotherRelativeiri')) {
+      if(info.relativeIri === 'relativeiri' ||
+         info.relativeIri === 'anotherRelativeiri') {
         expansionMapCalledTimes++;
       }
     };
 
     await jsonld.expand(docWithRelativeIriId, {expansionMap});
 
-    assert.equal(expansionMapCalledTimes, 2);
+    assert.equal(expansionMapCalledTimes, 3);
   });
 
   it('should be called on relative iri for \
@@ -649,7 +648,7 @@ describe('expansionMap', () => {
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+      if(info.relativeIri === 'relativeiri') {
         expansionMapCalled = true;
       }
     };
@@ -672,7 +671,7 @@ describe('expansionMap', () => {
 
     let expansionMapCalled = false;
     const expansionMap = info => {
-      if(info.relativeIri && info.relativeIri.value === 'relativeiri') {
+      if(info.relativeIri === 'relativeiri') {
         expansionMapCalled = true;
       }
     };

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -680,4 +680,24 @@ describe('expansionMap', () => {
 
     assert.equal(expansionMapCalled, true);
   });
+
+  it("should be called on relative iri when @base value is './'", async () => {
+    const docWithRelativeIriId = {
+      '@context': {
+        "@base": "./",
+      },
+      '@id': "absoluteiri",
+    };
+
+    let expansionMapCalled = false;
+    const expansionMap = info => {
+      if(info.relativeIri === '/absoluteiri') {
+        expansionMapCalled = true;
+      }
+    };
+
+    await jsonld.expand(docWithRelativeIriId, {expansionMap});
+
+    assert.equal(expansionMapCalled, true);
+  });
 });

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -501,7 +501,7 @@ describe('expansionMap', () => {
     assert.equal(expansionMapCalled, true);
   });
 
-  it('should be called on nested un-mapped term', async () => {
+  it('should be called on nested unmapped term', async () => {
     const docWithUnMappedTerm = {
       '@context': {
         'definedTerm': 'https://example.com#definedTerm'

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -398,7 +398,7 @@ function addManifest(manifest, parent) {
  */
 function addTest(manifest, test, tests) {
   // expand @id and input base
-  const test_id = test['@id'] || test['id'];
+  const test_id = test['@id'] || test.id;
   //var number = test_id.substr(2);
   test['@id'] =
     manifest.baseIri +
@@ -958,10 +958,10 @@ function createDocumentLoader(test) {
         }
 
         // If not JSON-LD, alternate may point there
-        if(linkHeaders['alternate'] &&
-          linkHeaders['alternate'].type == 'application/ld+json' &&
+        if(linkHeaders.alternate &&
+          linkHeaders.alternate.type == 'application/ld+json' &&
           !(contentType || '').match(/^application\/(\w*\+)?json$/)) {
-          doc.documentUrl = prependBase(url, linkHeaders['alternate'].target);
+          doc.documentUrl = prependBase(url, linkHeaders.alternate.target);
         }
       }
     }


### PR DESCRIPTION
As documented in #199 when the value of `@type` or `@id` is a relative IRI it is silently dropped when the resulting expanded object is converted to an RDF representation because RDF does not support relative IRIs. This is problematic for cases where a JSON-LD document is being digitally signed as information can be silently dropped.

This PR expands the `expansionMap` function so that it is called when a relative IRI is encountered when expanding an `@id` or `@type` value. This then allows libraries like [jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures) to throw errors through a custom [strict expansion map](https://github.com/digitalbazaar/jsonld-signatures/blob/master/lib/expansionMap.js#L6-L13).
