### PR TITLE
Improve compactIri performance

### DIFF
--- a/lib/compact.js
+++ b/lib/compact.js
@@ -929,13 +929,13 @@ api.compactIri = ({
 
   // If iri could be confused with a compact IRI using a term in this context,
   // signal an error
-  for(const [term, td] of activeCtx.mappings) {
-    if(td && td._prefix && iri.startsWith(term + ':')) {
-      throw new JsonLdError(
-        `Absolute IRI "${iri}" confused with prefix "${term}".`,
-        'jsonld.SyntaxError',
-        {code: 'IRI confused with prefix', context: activeCtx});
-    }
+  const scheme = iri.substr(0, iri.indexOf(':'));
+  const td = scheme && activeCtx.mappings.get(scheme);
+  if(td && td._prefix) {
+    throw new JsonLdError(
+      `Absolute IRI "${iri}" confused with prefix "${scheme}".`,
+      'jsonld.SyntaxError',
+      {code: 'IRI confused with prefix', context: activeCtx});
   }
 
   // compact IRI relative to base


### PR DESCRIPTION
Having some performance problems on some particularly large input. I noticed this quite costly loop that could be replaced with a Map lookup. Seems to reduce the overall runtime by about 50%.

for reference, the offending data: https://gist.githubusercontent.com/Janpot/792ae65f50d53a2903ffd87d29bec782/raw/51199036e09c9567ebfa4b04d03f5e207a39cdae/large-jsonld.json
encountered on this website: https://www.stanglwirt.com