### PR TITLE
Add support for xsd:float as native type

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,7 @@ module.exports = {
   XSD,
   XSD_BOOLEAN: XSD + 'boolean',
   XSD_DOUBLE: XSD + 'double',
+  XSD_FLOAT: XSD + 'float',
   XSD_INTEGER: XSD + 'integer',
   XSD_STRING: XSD + 'string',
 };

--- a/lib/fromRdf.js
+++ b/lib/fromRdf.js
@@ -326,7 +326,9 @@ function _RDFToObject(o, useNativeTypes, rdfDirection) {
         }
       }
       // do not add native type
-      if(![XSD_BOOLEAN, XSD_INTEGER, XSD_FLOAT, XSD_DOUBLE, XSD_STRING].includes(type)) {
+      // Remark: xsd:float are parsed into native type (above), but yet the type is explicitly added
+      // so as to keep the type information and not conflate xsd:float with xsd:double
+      if(![XSD_BOOLEAN, XSD_INTEGER, XSD_DOUBLE, XSD_STRING].includes(type)) {
         rval['@type'] = type;
       }
     } else if(rdfDirection === 'i18n-datatype' &&

--- a/lib/fromRdf.js
+++ b/lib/fromRdf.js
@@ -25,6 +25,7 @@ const {
   // XSD,
   XSD_BOOLEAN,
   XSD_DOUBLE,
+  XSD_FLOAT,
   XSD_INTEGER,
   XSD_STRING,
 } = require('./constants');
@@ -320,12 +321,12 @@ function _RDFToObject(o, useNativeTypes, rdfDirection) {
           if(i.toFixed(0) === rval['@value']) {
             rval['@value'] = i;
           }
-        } else if(type === XSD_DOUBLE) {
+        } else if(type === XSD_DOUBLE || type === XSD_FLOAT) {
           rval['@value'] = parseFloat(rval['@value']);
         }
       }
       // do not add native type
-      if(![XSD_BOOLEAN, XSD_INTEGER, XSD_DOUBLE, XSD_STRING].includes(type)) {
+      if(![XSD_BOOLEAN, XSD_INTEGER, XSD_FLOAT, XSD_DOUBLE, XSD_STRING].includes(type)) {
         rval['@type'] = type;
       }
     } else if(rdfDirection === 'i18n-datatype' &&


### PR DESCRIPTION
Currently, when parsing RDF using 'useNativeTypes', xsd:float is not recognized.
This fixes it.