### PR TITLE
Update expandMap and tests.

### DIFF
--- a/tests/misc.js
+++ b/tests/misc.js
@@ -479,7 +479,7 @@ describe('literal JSON', () => {
   });
 });
 
-describe('expansionMap', () => {
+describe.only('expansionMap', () => {
   describe('unmappedProperty', () => {
     it('should be called on unmapped term', async () => {
       const docWithUnMappedTerm = {
@@ -614,8 +614,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it('should be called on relative iri for type\
-     term in scoped context', async () => {
+    it('should be called on relative iri for type ' +
+      'term in scoped context', async () => {
       const docWithRelativeIriId = {
         '@context': {
           'definedType': {
@@ -645,8 +645,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it('should be called on relative iri for \
-    type term with multiple relative iri types', async () => {
+    it('should be called on relative iri for ' +
+      'type term with multiple relative iri types', async () => {
       const docWithRelativeIriId = {
         '@context': {
           'definedTerm': 'https://example.com#definedTerm'
@@ -669,8 +669,9 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalledTimes, 3);
     });
 
-    it('should be called on relative iri for \
-    type term with multiple relative iri types in scoped context', async () => {
+    it('should be called on relative iri for ' +
+      'type term with multiple relative iri types in scoped context' +
+      '', async () => {
       const docWithRelativeIriId = {
         '@context': {
           'definedType': {
@@ -701,8 +702,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalledTimes, 3);
     });
 
-    it('should be called on relative iri for \
-    type term with multiple types', async () => {
+    it('should be called on relative iri for ' +
+      'type term with multiple types', async () => {
       const docWithRelativeIriId = {
         '@context': {
           'definedTerm': 'https://example.com#definedTerm'
@@ -747,8 +748,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called on relative iri when \
-    @base value is './'", async () => {
+    it("should be called on relative iri when " +
+      "@base value is './'", async () => {
       const docWithRelativeIriId = {
         '@context': {
           "@base": "./",
@@ -768,8 +769,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called on relative iri when \
-    @base value is './'", async () => {
+    it("should be called on relative iri when " +
+      "@base value is './'", async () => {
       const docWithRelativeIriId = {
         '@context': {
           "@base": "./",
@@ -789,8 +790,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called on relative iri when \
-    @vocab value is './'", async () => {
+    it("should be called on relative iri when " +
+      "@vocab value is './'", async () => {
       const docWithRelativeIriId = {
         '@context': {
           "@vocab": "./",
@@ -812,8 +813,8 @@ describe('expansionMap', () => {
   });
 
   describe('prependedIri', () => {
-    it("should be called when property is \
-    being expanded with `@vocab`", async () => {
+    it("should be called when property is " +
+      "being expanded with `@vocab`", async () => {
       const doc = {
         '@context': {
           "@vocab": "http://example.com/",
@@ -838,8 +839,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called when '@type' is \
-    being expanded with `@vocab`", async () => {
+    it("should be called when '@type' is " +
+      "being expanded with `@vocab`", async () => {
       const doc = {
         '@context': {
           "@vocab": "http://example.com/",
@@ -864,8 +865,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called when aliased '@type' is \
-    being expanded with `@vocab`", async () => {
+    it("should be called when aliased '@type' is " +
+      "being expanded with `@vocab`", async () => {
       const doc = {
         '@context': {
           "@vocab": "http://example.com/",
@@ -891,8 +892,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called when '@id' is being \
-    expanded with `@base`", async () => {
+    it("should be called when '@id' is being " +
+      "expanded with `@base`", async () => {
       const doc = {
         '@context': {
           "@base": "http://example.com/",
@@ -919,8 +920,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called when aliased '@id' \
-    is being expanded with `@base`", async () => {
+    it("should be called when aliased '@id' " +
+      "is being expanded with `@base`", async () => {
       const doc = {
         '@context': {
           "@base": "http://example.com/",
@@ -948,8 +949,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called when '@type' is \
-    being expanded with `@base`", async () => {
+    it("should be called when '@type' is " +
+      "being expanded with `@base`", async () => {
       const doc = {
         '@context': {
           "@base": "http://example.com/",
@@ -976,8 +977,8 @@ describe('expansionMap', () => {
       assert.equal(expansionMapCalled, true);
     });
 
-    it("should be called when aliased '@type' is \
-    being expanded with `@base`", async () => {
+    it("should be called when aliased '@type' is " +
+      "being expanded with `@base`", async () => {
       const doc = {
         '@context': {
           "@base": "http://example.com/",


### PR DESCRIPTION
This is a continuation of the expansionMap work from:
https://github.com/digitalbazaar/jsonld.js/pull/452

@tplooker This likely needs your input.

That expansionMap work was merged but never released. I wanted to get it out there and active for use in VCs and elsewhere to at least try and check for dropped types and such. It turns out I don't know how to use this feature! `expansionMap` is now called lots more than before. It has many variations, and the lack of documentation is now rather painful, since it's not obvious what the `expansionMap` code should do for what situations.

In the case of VCs, it seems like type scoped properties like `credentialSubject` end up with a couple calls, but maybe it shouldn't? Perhaps the callback is getting called while the algorithm does normal processing rather than just when there's an issue?

In any case, I updated the tests to count all the calls to `expansionMap`, and (maybe) what they were for.  Just so it's clear in examples what is happening.

I do think some more test cases are needed, if for nothing else than as an example. Have various inputs that have unknown properties, types, etc, and an example `expansionMap` handler that knows how to reject all that. Basically a common use case for strict signing software.