### PR TITLE
Update to `@digitalbazaar/http-client@3`.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,11 @@ module.exports = {
     es2020: true
   },
   extends: 'eslint-config-digitalbazaar',
-  root: true
+  root: true,
+  ignorePatterns: [
+    'dist/',
+    'tests/webidl/WebIDLParser.js',
+    'tests/webidl/idlharness.js',
+    'tests/webidl/testharness.js'
+  ]
 };

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # jsonld ChangeLog
 
-## 5.3.0 - 2022-xx-xx
+## 6.0.0 - 2022-xx-xx
 
 ### Changed
+- **BREAKING**: Drop testing and support for Node.js 12.x. The majority of the
+  code will still run on Node.js 12.x. However, the
+  `@digitalbazaar/http-client@3` update uses a newer `ky-universal` which uses
+  a top-level `await` that is unsupported in older Node.js versions. That
+  causes the included `node` `documentLoader` to not function and tests to
+  fail. If you wish to still use earlier Node.js versions, you may still be
+  able to do so with your own custom `documentLoader`.
 - Update to `@digitalbazaar/http-client@3`:
   - Pulls in newer `ky` and `ky-universal` that should address security alerts
     and provide other improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # jsonld ChangeLog
 
+## 5.3.0 - 2022-xx-xx
+
+### Changed
+- Update to `@digitalbazaar/http-client@3`:
+  - Pulls in newer `ky` and `ky-universal` that should address security alerts
+    and provide other improvements.
+  - Use global `URL` interface to handle relative redirects.
+
 ## 5.2.0 - 2021-04-07
 
 ### Changed

--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -143,7 +143,9 @@ module.exports = ({
           });
       }
       redirects.push(url);
-      return loadDocument(location, redirects);
+      // location can be relative, turn into full url
+      const nextUrl = new URL(location, url).href;
+      return loadDocument(nextUrl, redirects);
     }
 
     // cache for each redirected URL
@@ -163,7 +165,12 @@ module.exports = ({
 
 async function _fetch({url, headers, strictSSL, httpAgent, httpsAgent}) {
   try {
-    const options = {headers, redirect: 'manual'};
+    const options = {
+      headers,
+      redirect: 'manual',
+      // ky specific to avoid redirects throwing
+      throwHttpErrors: false
+    };
     const isHttps = url.startsWith('https:');
     if(isHttps) {
       options.agent =
@@ -174,7 +181,13 @@ async function _fetch({url, headers, strictSSL, httpAgent, httpsAgent}) {
       }
     }
     const res = await httpClient.get(url, options);
-    return {res, body: res.data};
+    // @digitalbazaar/http-client may use node-fetch, which can output
+    // a warning if response.data is accessed and no json was parsed.
+    // Used here is the same type detection logic so the data field is
+    // accessed only if the client likely tried to parse JSON.
+    const contentType = res.headers.get('content-type');
+    const hasJson = contentType && contentType.includes('json');
+    return {res, body: hasJson ? res.data : null};
   } catch(e) {
     // HTTP errors have a response in them
     // ky considers redirects HTTP errors

--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -110,7 +110,7 @@ module.exports = ({
       }
 
       // "alternate" link header is a redirect
-      alternate = linkHeaders['alternate'];
+      alternate = linkHeaders.alternate;
       if(alternate &&
         alternate.type == 'application/ld+json' &&
         !(contentType || '')

--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -181,13 +181,7 @@ async function _fetch({url, headers, strictSSL, httpAgent, httpsAgent}) {
       }
     }
     const res = await httpClient.get(url, options);
-    // @digitalbazaar/http-client may use node-fetch, which can output
-    // a warning if response.data is accessed and no json was parsed.
-    // Used here is the same type detection logic so the data field is
-    // accessed only if the client likely tried to parse JSON.
-    const contentType = res.headers.get('content-type');
-    const hasJson = contentType && contentType.includes('json');
-    return {res, body: hasJson ? res.data : null};
+    return {res, body: res.data};
   } catch(e) {
     // HTTP errors have a response in them
     // ky considers redirects HTTP errors

--- a/lib/documentLoaders/xhr.js
+++ b/lib/documentLoaders/xhr.js
@@ -90,7 +90,7 @@ module.exports = ({
       }
 
       // "alternate" link header is a redirect
-      alternate = linkHeaders['alternate'];
+      alternate = linkHeaders.alternate;
       if(alternate &&
         alternate.type == 'application/ld+json' &&
         !(contentType || '').match(/^application\/(\w*\+)?json$/)) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -130,7 +130,7 @@ api.parseLinkHeader = header => {
     while((match = REGEX_LINK_HEADER_PARAMS.exec(params))) {
       result[match[1]] = (match[2] === undefined) ? match[3] : match[2];
     }
-    const rel = result['rel'] || '';
+    const rel = result.rel || '';
     if(Array.isArray(rval[rel])) {
       rval[rel].push(result);
     } else if(rval.hasOwnProperty(rel)) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalbazaar/http-client": "^3.0.1",
+    "@digitalbazaar/http-client": "^3.1.0",
     "canonicalize": "^1.0.1",
     "lru-cache": "^6.0.0",
     "rdf-canonize": "^3.0.0"
@@ -78,7 +78,7 @@
     "webpack-merge": "^5.7.3"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "keywords": [
     "JSON",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalbazaar/http-client": "^1.1.0",
+    "@digitalbazaar/http-client": "^3.0.1",
     "canonicalize": "^1.0.1",
     "lru-cache": "^6.0.0",
     "rdf-canonize": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test",
     "coverage-report": "nyc report",
-    "lint": "eslint *.js lib/**.js tests/**.js"
+    "lint": "eslint ."
   },
   "nyc": {
     "exclude": [

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -398,7 +398,7 @@ function addManifest(manifest, parent) {
  */
 function addTest(manifest, test, tests) {
   // expand @id and input base
-  const test_id = test['@id'] || test['id'];
+  const test_id = test['@id'] || test.id;
   //var number = test_id.substr(2);
   test['@id'] =
     manifest.baseIri +
@@ -958,10 +958,10 @@ function createDocumentLoader(test) {
         }
 
         // If not JSON-LD, alternate may point there
-        if(linkHeaders['alternate'] &&
-          linkHeaders['alternate'].type == 'application/ld+json' &&
+        if(linkHeaders.alternate &&
+          linkHeaders.alternate.type == 'application/ld+json' &&
           !(contentType || '').match(/^application\/(\w*\+)?json$/)) {
-          doc.documentUrl = prependBase(url, linkHeaders['alternate'].target);
+          doc.documentUrl = prependBase(url, linkHeaders.alternate.target);
         }
       }
     }

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -35,6 +35,9 @@ const TEST_TYPES = {
       // NOTE: idRegex format:
       //MMM-manifest#tNNN$/,
       idRegex: [
+        /compact-manifest#t0111$/,
+        /compact-manifest#t0112$/,
+        /compact-manifest#t0113$/,
         // html
         /html-manifest#tc001$/,
         /html-manifest#tc002$/,


### PR DESCRIPTION
- Pulls in newer `ky` and `ky-universal` that should address security
  alerts and provide other improvements.
- Newer `ky` will throw errors on redirects even when in `manual`
  redirect mode. Now using `throwHttpErrors` option to turn off errors.
- One of the updated dependencies can cause tests to rewrite redirect
  `Location` URLs to be relative references. The global `URL` interface
  is now used to rebuild a full URL for further redirect processing.
- Newer `node-forge` will output a one-time warning if code even
  accesses `response.data`. `@digitalbazar/http-client` will forcefully
  set `data` *if* it detects a JSON content type. Calling code can't
  know if that happened, so currently needs to redo content detection to
  know if JSON `data` can be accessed. This is an issue for sites where
  JSON-LD was requested but the response is non-JSON with a `Link`
  header pointing to the JSON-LD.