### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 npm-debug.log
 tests/webidl/*-new
 v8.log
+test-suites

--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -143,7 +143,12 @@ module.exports = ({
           });
       }
       redirects.push(url);
-      return loadDocument(location, redirects);
+
+      // Ensure the redirect URL is resolved relative to the initial URL
+      // This supports relative Location headers and absolute:
+      const nextLocation = new URL(location, url).toString();
+
+      return loadDocument(nextLocation, redirects);
     }
 
     // cache for each redirected URL

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalbazaar/http-client": "^1.1.0",
+    "@digitalbazaar/http-client": "^3.2.0",
     "canonicalize": "^1.0.1",
     "lru-cache": "^6.0.0",
     "rdf-canonize": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@digitalbazaar/http-client": "^3.2.0",
     "canonicalize": "^1.0.1",
-    "lru-cache": "^6.0.0",
+    "lru-cache": "^7.10.1",
     "rdf-canonize": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "webpack-merge": "^5.7.3"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14.0"
   },
   "keywords": [
     "JSON",


### PR DESCRIPTION
Whilst working on some Inrupt code, I noticed that the jsonld.js dependencies were quite out of date, and this could be causing an issue we're seeing where in node, the http-client fails to load correctly.

This upgrades the direct dependencies to their latest versions, and fixes a minor issue that introduced regarding the 3xx Location redirects.