### PR TITLE
Fix toRDF event names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # jsonld ChangeLog
 
+## 8.1.0 - 2022-xx-xx
+
+### Fixed
+- `relative property reference` event renamed to `relative predicate
+  reference`.
+- `relative type reference` event renamed to `relative object reference`.
+
 ## 8.0.0 - 2022-08-23
 
 ### Changed

--- a/lib/events.js
+++ b/lib/events.js
@@ -121,9 +121,9 @@ const _notSafeEventCodes = new Set([
   // toRDF
   'blank node predicate',
   'relative graph reference',
-  'relative property reference',
-  'relative subject reference',
-  'relative type reference'
+  'relative object reference',
+  'relative predicate reference',
+  'relative subject reference'
 ]);
 
 // safe handler that rejects unsafe warning conditions

--- a/lib/toRdf.js
+++ b/lib/toRdf.js
@@ -154,11 +154,11 @@ function _graphToRDF(dataset, graph, graphTerm, issuer, options) {
             _handleEvent({
               event: {
                 type: ['JsonLdEvent'],
-                code: 'relative property reference',
+                code: 'relative predicate reference',
                 level: 'warning',
-                message: 'Relative property reference found.',
+                message: 'Relative predicate reference found.',
                 details: {
-                  property
+                  predicate: property
                 }
               },
               options
@@ -345,11 +345,11 @@ function _objectToRDF(
       _handleEvent({
         event: {
           type: ['JsonLdEvent'],
-          code: 'relative type reference',
+          code: 'relative object reference',
           level: 'warning',
-          message: 'Relative type reference found.',
+          message: 'Relative object reference found.',
           details: {
-            type: object.value
+            object: object.value
           }
         },
         options

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -3272,7 +3272,7 @@ _:b0 <ex:p> "v" .
       });
     });
 
-    it('should handle relative property reference', async () => {
+    it('should handle relative predicate reference', async () => {
       const input =
 [
   {
@@ -3293,14 +3293,14 @@ _:b0 <ex:p> "v" .
         options: {skipExpansion: true},
         expected: nq,
         eventCodeLog: [
-          'relative property reference'
+          'relative predicate reference'
           // .. 'rel'
         ],
         testNotSafe: true
       });
     });
 
-    it('should handle relative property reference', async () => {
+    it('should handle relative object reference', async () => {
       const input =
 [
   {
@@ -3325,7 +3325,7 @@ _:b0 <ex:p> "v" .
         options: {skipExpansion: true},
         expected: nq,
         eventCodeLog: [
-          'relative type reference'
+          'relative object reference'
           // .. 'rel'
         ],
         testNotSafe: true


### PR DESCRIPTION
These are exposed in errors, but since events are not yet "public", and these are fixes, targeting this as a minor release.

- `relative property reference` event renamed to `relative predicate
  reference`.
- `relative type reference` event renamed to `relative object
  reference`.