### PR TITLE
Correct `canonize` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ const framed = await jsonld.frame(doc, frame);
 // (URDNA2015), see:
 const canonized = await jsonld.canonize(doc, {
   algorithm: 'URDNA2015',
-  format: 'application/n-quads'
+  inputFormat: 'application/n-quads'
 });
 // canonized is a string that is a canonical representation of the document
 // that can be used for hashing, comparison, etc.


### PR DESCRIPTION
The docs on the README for `canonize` state:

```js
const canonized = await jsonld.canonize(doc, {
  algorithm: 'URDNA2015',
  format: 'application/n-quads'
});
```

In order to properly accept n-quads the option needs to be:

```js
const canonized = await jsonld.canonize(doc, {
  algorithm: 'URDNA2015',
  inputFormat: 'application/n-quads'
});
```