### PR TITLE
Fix for issue with frame validation when type is `@json`

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -465,7 +465,7 @@ function _validateFrame(frame) {
   if('@type' in frame[0]) {
     for(const type of util.asArray(frame[0]['@type'])) {
       // @id must be wildcard or an IRI
-      if(!(types.isObject(type) || url.isAbsolute(type)) ||
+      if(!(types.isObject(type) || url.isAbsolute(type) || (type === '@json')) ||
         (types.isString(type) && type.indexOf('_:') === 0)) {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; invalid @type in frame.',


### PR DESCRIPTION
# Problem

The problem arises when we try to generate a `derivedProof` from a JSON-LD Credential by using a `frameDocument` (also called `revealDocument`) which wants to disclose a field whose type is defined as `@json` inside the credential context.

## Use-case scenario

To explain better the issue let me draft a real use-case scenario where the problem arises. I own a [VDL Credential](https://w3c-ccg.github.io/vdl-vocab/) which looks like the following:

```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/vdl/v1",
    "https://w3id.org/security/bbs/v1"
  ],
  "type": [
    "VerifiableCredential",
    "Iso18013DriversLicenseCredential"
  ],
  "credentialSubject": {
    "id": "did:key:z6MkiiViqftXJKZNnWwpS7aKM7jiJBbGiFEZzPSKYB8p8oyy",
    "license": {
      "type": "Iso18013DriversLicense",
      "document_number": "542426814",
      "family_name": "TURNER",
      "given_name": "SUSAN",
      "portrait": "/9j/4AAQSkZJRgABAQEAkACQA...gcdgck5HtRRSClooooP/2Q==",
      "birth_date": "1998-08-28",
      "issue_date": "2018-01-15T10:00:00Z",
      "expiry_date": "2022-08-27T12:00:00Z",
      "issuing_country": "US",
      "issuing_authority": "AL",
      "driving_privileges": [
        {
          "codes": [
            {
              "code": "D"
            }
          ],
          "vehicle_category_code": "D",
          "issue_date": "2019-01-01",
          "expiry_date": "2027-01-01"
        },
        {
          "codes": [
            {
              "code": "C"
            }
          ],
          "vehicle_category_code": "C",
          "issue_date": "2019-01-01",
          "expiry_date": "2017-01-01"
        }
      ],
      "un_distinguishing_sign": "USA"
    }
  },
  "proof": {
    "type": "BbsBlsSignature2020",
    "created": "2022-12-01T12:37:18Z",
    "proofPurpose": "assertionMethod",
    "proofValue": "qYbNq0bTdOa+XeHJ8+vQsdFFUOxF2crZMqJsMWvLyy+wLRMm5sNelzoqgJDrFMnfXjZlTy4XBKlOh0rdQtxKRE9VHeH50eYYrXIrcrbsOhYNEyp45kkFpaFgLT5diA71qYzVYhVrzt86NCr5oWHvkg==",
    "verificationMethod": "did:example:489398593#test"
  }
}
```

The verifier provides me the following `frameDocument` to disclose only some fields of the VDL Credential:

```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/vdl/v1",
    "https://w3id.org/security/bbs/v1"
  ],
  "type": ["VerifiableCredential", "Iso18013DriversLicenseCredential"],
  "credentialSubject": {
    "@explicit": true,
    "license": {
      "type": "Iso18013DriversLicense",
      "@explicit": true,
      "birth_date": {},
      "document_number": {},
      "expiry_date": {},
      "issuing_authority": {},
      "driving_privileges": {}
    }
  }
}
```

Among the requested fields there is the `driving_privileges` one which is defined as `"@type": "@json"` inside the VLD context (available [here](https://github.com/w3c-ccg/vdl-vocab/blob/main/context/v1.jsonld)). 

The goal is to produce a `derivedProof` containing the requested fields which performs correctly when verified.

## Expected behaviour

The frame gets validated and used to produce a `derivedProof` as the following one:

```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/vdl/v1",
    "https://w3id.org/security/bbs/v1"
  ],
  "id": "urn:bnid:_:c14n0",
  "type": [
    "Iso18013DriversLicenseCredential",
    "VerifiableCredential"
  ],
  "credentialSubject": {
    "id": "did:key:z6MkiiViqftXJKZNnWwpS7aKM7jiJBbGiFEZzPSKYB8p8oyy",
    "license": {
      "id": "urn:bnid:_:c14n1",
      "type": "Iso18013DriversLicense",
      "birth_date": "1998-08-28",
      "document_number": "542426814",
      "driving_privileges": [
        {
          "codes": [
            {
              "code": "D"
            }
          ],
          "expiry_date": "2027-01-01",
          "issue_date": "2019-01-01",
          "vehicle_category_code": "D"
        },
        {
          "codes": [
            {
              "code": "C"
            }
          ],
          "expiry_date": "2017-01-01",
          "issue_date": "2019-01-01",
          "vehicle_category_code": "C"
        }
      ],
      "expiry_date": "2022-08-27T12:00:00Z",
      "issuing_authority": "AL"
    }
  },
  "proof": {
    "type": "BbsBlsSignatureProof2020",
    "created": "2022-12-01T12:43:45Z",
    "nonce": "hRg1hNhdBbsbQxTwK0ELyJh3kNtbMkTx42mLBi/An7IWZyDisVVy0b/u92dXqwCba7k=",
    "proofPurpose": "assertionMethod",
    "proofValue": "ABQBH/+3WRxSu8ebwOuHBjNFggw/oDwAfIlQqCBBa5mbjkVc6p+TvTLh+bv1HJ8eijLnNtSg+pgh2XEaxvdiKvkdVafJgYiWkLyIfdOsiBPPWiRTbXhjLE9klYQKWH8ZthU5Ub2JDLER/4A+oJ4CGP7jj0I+CPXt8SosYR+dUMMzd0rmFyyyDAMhZWh88TH3HUCY6bsAAAB0iw98nUtHdc5/cCIPrd9Dx3v+cj8vvJwHCbn9lYMx+p6TnIsF/6DbLErSpsqkO3NyAAAAAhKYEHO8iSQhQwCqaZECE3Y7YOPNZCGT7UfOIHwVCdwmDXaDb9CrtEp2sBRL3v5Ra9mskfkiN4KMh5vvj7XIAGm2Q2B3NmnNAlOYH5V0AoXVZzlFhNkGWsWsGHPD7dLplx8FYL8HO4VSp7SVf33///QAAAAIC17FayyxWRzFbxWQDf5AYtC0mOejFu1UdqdsxOKF19olrrRD17/a/HUQUNTTT0AlGGOLUSOLEvSFmk34l8wuoScNQkQulD81AiIy54c/lwfzLZ36h7VdnJUZeEGYpwVkcrPL/hebOpVjQoa+kLno0rMeAGywbBRPSPrM8eaHXhYy2t0FwXD89sqyYDQumxnomRHt5ZnG6bTwX7BNsm/KRkjkAfrAbYsaCqqK64lZRV8XL+2QQCPpxzZVWLaarh3aCAjWRr06CovvJzqtBTHz1eOWt+H7ld8RdBds3CWfG5RneUgOcfgyanGjjHoYRoyBdr1fWTA0NACrru+2TGQanQ==",
    "verificationMethod": "did:example:489398593#test"
  }
}
```

## Actual behaviour

The process stops when validating the frame (i.e. before generating the `derivedProof`) complaining that the attribute `driving_privileges` has an invalid type `@json`:

```
JsonLdError [jsonld.SyntaxError]: Invalid JSON-LD syntax; invalid @type in frame.
    at _validateFrame (bbs/node_modules/jsonld/lib/frame.js:470:15)
    at _filterSubject (bbs/node_modules/jsonld/lib/frame.js:573:9)
    at _filterSubjects (bbs/node_modules/jsonld/lib/frame.js:493:8)
    at Object.api.frame (bbs/node_modules/jsonld/lib/frame.js:96:19)
    at Object.api.frame (bbs/node_modules/jsonld/lib/frame.js:258:15)
    at Object.api.frame (bbs/node_modules/jsonld/lib/frame.js:258:15)
    at api.frameMergedOrDefault (bbs/node_modules/jsonld/lib/frame.js:53:7)
    at Function.jsonld.frame (bbs/node_modules/jsonld/lib/jsonld.js:490:18)
    at async BbsBlsSignatureProof2020.deriveProof (bbs/node_modules/@mattrglobal/jsonld-signatures-bbs/lib/BbsBlsSignatureProof2020.js:106:38)
    at async exports.deriveProof (bbs/node_modules/@mattrglobal/jsonld-signatures-bbs/lib/deriveProof.js:48:20)
```

As the stack trace shows, the error is located inside this library, therefore our PR to try to solve this issue.

## Our Solution

We added the type `@json` among the ones which can be considered valid in the frame validation. By doing this the process runs fine and the `derivedProof` is generated correctly (the one I've put inside the **Expected Behaviour** section has been generated once we applied the fix defined inside this PR.

I remind that the type `@json` is an official type as indicated in the [JSON-LD specs](https://www.w3.org/TR/json-ld11/#json-literals).