### PR TITLE
init ipfs in default document loader

### DIFF
--- a/lib/documentLoaders/node.js
+++ b/lib/documentLoaders/node.js
@@ -56,13 +56,14 @@ module.exports = ({
   async function loadDocument(url, redirects) {
     const isHttp = url.startsWith('http:');
     const isHttps = url.startsWith('https:');
-    if(!isHttp && !isHttps) {
+    const isIpfs = url.startsWith('ipfs:');
+    if(!isHttp && !isHttps && !isIpfs) {
       throw new JsonLdError(
-        'URL could not be dereferenced; only "http" and "https" URLs are ' +
+        'URL could not be dereferenced; only "http", "https" and "ipfs" URLs are ' +
         'supported.',
         'jsonld.InvalidUrl', {code: 'loading document failed', url});
     }
-    if(secure && !isHttps) {
+    if(secure && isHttp) {
       throw new JsonLdError(
         'URL could not be dereferenced; secure mode is enabled and ' +
         'the URL\'s scheme is not "https".',
@@ -76,8 +77,10 @@ module.exports = ({
 
     let alternate = null;
 
+    const requestUrl = !isIpfs ? url : 'https://ipfs.io/ipfs/' + url.split('ipfs://')[1];
+
     const {res, body} = await _fetch({
-      url, headers, strictSSL, httpAgent, httpsAgent
+      requestUrl, headers, strictSSL, httpAgent, httpsAgent
     });
     doc = {contextUrl: null, documentUrl: url, document: body || null};
 

--- a/lib/documentLoaders/xhr.js
+++ b/lib/documentLoaders/xhr.js
@@ -32,22 +32,24 @@ module.exports = ({
   return queue.wrapLoader(loader);
 
   async function loader(url) {
-    if(url.indexOf('http:') !== 0 && url.indexOf('https:') !== 0) {
+    if(url.indexOf('http:') !== 0 && url.indexOf('https:') !== 0 && url.indexOf('ipfs:') !== 0) {
       throw new JsonLdError(
-        'URL could not be dereferenced; only "http" and "https" URLs are ' +
+        'URL could not be dereferenced; only "http", "https" and "ipfs" URLs are ' +
         'supported.',
         'jsonld.InvalidUrl', {code: 'loading document failed', url});
     }
-    if(secure && url.indexOf('https') !== 0) {
+    if(secure && (url.indexOf('https') !== 0 || url.indexOf('ipfs') !== 0)) {
       throw new JsonLdError(
         'URL could not be dereferenced; secure mode is enabled and ' +
         'the URL\'s scheme is not "https".',
         'jsonld.InvalidUrl', {code: 'loading document failed', url});
     }
 
+    const requestUrl = url.indexOf('ipfs:') === 0 ? 'https://ipfs.io/ipfs/' + url.split('ipfs://')[1] : url;
+
     let req;
     try {
-      req = await _get(xhr, url, headers);
+      req = await _get(xhr, requestUrl, headers);
     } catch(e) {
       throw new JsonLdError(
         'URL could not be dereferenced, an error occurred.',


### PR DESCRIPTION
Simple IPFS support in the default document loader with origin https://github.com/digitalbazaar/jsonld.js/issues/512

Could be improved with the use of multiple public gateways and `Promise.any()` as shown in the issue above.