### PR TITLE
Skip rdf-canon test with U escapes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 8.1.2 - 2023-03-xx
 
 ### Changed
-- Update for latest [rdf-canon][] changes: test suite location, README,
-  links, and identifiers.
+- Update for latest [rdf-canon][] changes: test suite location, README, links,
+  and identifiers.
+  - Skip test with 'U' escapes. Will enable when [rdf-canonize][] dependency is
+    updated.
 
 ## 8.1.1 - 2023-02-25
 

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -259,6 +259,14 @@ const TEST_TYPES = {
     compare: compareExpectedNQuads
   },
   'rdfc:Urdna2015EvalTest': {
+    skip: {
+      // NOTE: idRegex format:
+      //manifest-urdna2015#testNNN$/,
+      idRegex: [
+        // Unsupported U escape
+        /manifest-urdna2015#test060/
+      ]
+    },
     fn: 'normalize',
     params: [
       readTestNQuads('action'),


### PR DESCRIPTION
Will enable when rdf-canonize dependency is updated.