### PR TITLE
fix: incorrect @id expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ coverage
 dist
 node_modules
 npm-debug.log
+package-lock.json
 tests/webidl/*-new
 v8.log

--- a/lib/url.js
+++ b/lib/url.js
@@ -109,6 +109,8 @@ api.prependBase = (base, iri) => {
         path = path.substr(0, path.lastIndexOf('/') + 1);
         if((path.length > 0 || base.authority) && path.substr(-1) !== '/') {
           path += '/';
+        } else if (rel.protocol) {
+          path += rel.protocol;
         }
         path += rel.path;
 

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -1491,6 +1491,7 @@ _:b0 <ex:p> "v" .
         testSafe: true
       });
     });
+
   });
 
   describe('values', () => {
@@ -2607,6 +2608,37 @@ _:b0 <ex:p> "[null]"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .
           //// .. 'relativeiri'
           'relative @id reference'
           // .. 'relativeiri'
+        ],
+        testNotSafe: true
+      });
+    });
+
+    it('should be called on relative IRI for id term [4]', async () => {
+      const input =
+{
+  "@id": "34:relativeiri",
+  "urn:test": "value"
+}
+;
+      const expected =
+[
+  {
+    "@id": "34:relativeiri",
+    "urn:test": [
+      {
+        "@value": "value"
+      }
+    ]
+  }
+]
+;
+
+      await _test({
+        type: 'expand',
+        input,
+        expected,
+        eventCodeLog: [
+          'relative @id reference'
         ],
         testNotSafe: true
       });


### PR DESCRIPTION
### What
This PR provides a way to avoid `@id` modification in case it contains `:` and it's not really an URI.
I'm not too familiar with the codebase so I just added a test case and a quick fix, but I'm more than available to adjust it based on feedback. 

### Why
We're trying to expand json documents that have `@id`s that contain `:` but they aren't really URIs.
The behavior has been described in #523.


Closes: #523 