### PR TITLE
Fix relative IRI parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ coverage
 dist
 node_modules
 npm-debug.log
+package-lock.json
 tests/webidl/*-new
 v8.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix safe mode for `@graph` use cases.
   - Check all elements of graph property with array.
 - Fix test `pr41` of protected redefinition of equivalent id terms.
+- Fix relative IRI parsing.
 
 ## 8.2.0 - 2023-05-19
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -109,6 +109,8 @@ api.prependBase = (base, iri) => {
         path = path.substr(0, path.lastIndexOf('/') + 1);
         if((path.length > 0 || base.authority) && path.substr(-1) !== '/') {
           path += '/';
+        } else if (rel.protocol) {
+          path += rel.protocol;
         }
         path += rel.path;
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -28,7 +28,7 @@ api.parsers = {
       'hostname', 'port', 'path', 'directory', 'file', 'query', 'fragment'
     ],
     /* eslint-disable-next-line max-len */
-    regex: /^(([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?(?:(((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/
+    regex: /^(([a-zA-Z][a-zA-Z0-9+-.]*):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?(?:(((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/
   }
 };
 api.parse = (str, parser) => {
@@ -109,8 +109,6 @@ api.prependBase = (base, iri) => {
         path = path.substr(0, path.lastIndexOf('/') + 1);
         if((path.length > 0 || base.authority) && path.substr(-1) !== '/') {
           path += '/';
-        } else if (rel.protocol) {
-          path += rel.protocol;
         }
         path += rel.path;
 

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -1491,7 +1491,6 @@ _:b0 <ex:p> "v" .
         testSafe: true
       });
     });
-
   });
 
   describe('values', () => {

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -1491,6 +1491,7 @@ _:b0 <ex:p> "v" .
         testSafe: true
       });
     });
+
   });
 
   describe('values', () => {
@@ -2811,6 +2812,37 @@ _:b0 <ex:p> "[null]"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .
           //// .. 'relativeiri'
           'relative @id reference'
           // .. 'relativeiri'
+        ],
+        testNotSafe: true
+      });
+    });
+
+    it('should be called on relative IRI for id term [4]', async () => {
+      const input =
+{
+  "@id": "34:relativeiri",
+  "urn:test": "value"
+}
+;
+      const expected =
+[
+  {
+    "@id": "34:relativeiri",
+    "urn:test": [
+      {
+        "@value": "value"
+      }
+    ]
+  }
+]
+;
+
+      await _test({
+        type: 'expand',
+        input,
+        expected,
+        eventCodeLog: [
+          'relative @id reference'
         ],
         testNotSafe: true
       });


### PR DESCRIPTION
- Based on https://github.com/digitalbazaar/jsonld.js/pull/527.
- Changed to fix the IRI parser to only accept valid RFC3986 URI schemes.
- Closes https://github.com/digitalbazaar/jsonld.js/issues/523.