### PR TITLE
Fix `@graph` `@container` term `@context` handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # jsonld ChangeLog
 
+## 8.3.2 - 2023-xx-xx
+
+### Fixed
+- Fix handling of a `@graph` `@container` term that has a `null` `@context`.
+
 ## 8.3.1 - 2023-09-06
 
 ### Fixed

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -856,7 +856,7 @@ async function _expandObject({
       });
     }
 
-    const container = _getContextValue(termCtx, key, '@container') || [];
+    const container = _getContextValue(activeCtx, key, '@container') || [];
 
     if(container.includes('@language') && _isObject(value)) {
       const direction = _getContextValue(termCtx, key, '@direction');


### PR DESCRIPTION
When a term scoped context is nullified, it also nullifies the container information. This fix gets the `@container` value from the active context. In particular, this is needed for proper `@graph` container handling.

It is a bit difficult to reason about the correctness of this fix.  All test suite tests including the additional one related to this issue pass.  But more esoteric untested JSON-LD structures may not?

https://github.com/w3c/json-ld-api/pull/582
https://github.com/w3c/vc-data-model/issues/1373