### PR TITLE
Ignore `test-suites/` directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 package-lock.json
 tests/webidl/*-new
 v8.log
+test-suites/


### PR DESCRIPTION
It should never be committed as it contains upstream test suite content.
