### PR TITLE
Update README to use default export and destructure on default export.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ jspm install npm:jsonld
 ```
 
 ``` js
-import * as jsonld from 'jsonld';
+import jsonld from 'jsonld';
 // or
-import {promises} from 'jsonld';
+const {promises} = jsonld;
 // or
-import {JsonLdProcessor} from 'jsonld';
+const {JsonLdProcessor} = jsonld;
 ```
 
 ### Node.js native canonize bindings


### PR DESCRIPTION
Updates the README so the es6 import examples work.