### PR TITLE
Bump http-client version to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@digitalbazaar/http-client": "^3.4.1",
+    "@digitalbazaar/http-client": "^4.1.1",
     "canonicalize": "^1.0.1",
     "lru-cache": "^6.0.0",
     "rdf-canonize": "^3.4.0"


### PR DESCRIPTION
The package was still relying on an older 3.x version of http-client that depended on a version of `ky` that required `ky-universal` which causes issues as it has a top-level await. The latest version of `ky` no longer has this dependency, and `http-client` no longer depends on this old version since https://github.com/digitalbazaar/http-client/commit/895bdd25dbc44381b61033bf4611c1da36a90613 (in Sept. 2023).