### PR TITLE
Move platform code to index so that lib/jsonld is platform-independent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,4 +5,8 @@
  *
  * Copyright 2010-2021 Digital Bazaar, Inc.
  */
-module.exports = require('./jsonld');
+const platform = require('./platform');
+const jsonld = require('./jsonld');
+platform.setupGlobals(jsonld);
+platform.setupDocumentLoaders(jsonld);
+module.exports = jsonld;

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -34,7 +34,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 const canonize = require('rdf-canonize');
-const platform = require('./platform');
 const util = require('./util');
 const ContextResolver = require('./ContextResolver');
 const IdentifierIssuer = util.IdentifierIssuer;
@@ -1023,9 +1022,6 @@ jsonld.RequestQueue = require('./RequestQueue');
 
 /* WebIDL API */
 jsonld.JsonLdProcessor = require('./JsonLdProcessor')(jsonld);
-
-platform.setupGlobals(jsonld);
-platform.setupDocumentLoaders(jsonld);
 
 function _setDefaults(options, {
   documentLoader = jsonld.documentLoader,

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     ]
   },
   "browser": {
-    "./lib/index.js": "./lib/jsonld.js",
+    "./lib/index.js": "./lib/index.js",
     "./lib/platform.js": "./lib/platform-browser.js",
     "crypto": false,
     "http": false,


### PR DESCRIPTION
Hello,

I am opening this PR because I would like to use jsonld without the default document loader.
With this PR, I can use `import jsonld from 'jsonld/lib/jsonld'`, and the default document loader (which requires a dependency on `@digitalbazaar/http-client`) will not be included.
