### PR TITLE
Update README with ES6 import example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ npm install jsonld
 const jsonld = require('jsonld');
 ```
 
+```js
+import jsonld from 'jsonld';
+```
+
 ### Browser (bundler) + npm
 
 ```


### PR DESCRIPTION
Add ES6 import syntax for `jsonld` in README.

The other import styles will not work with Node.js, so this marks out the happy path for Node devs.